### PR TITLE
Add fighter network graph visualization

### DIFF
--- a/panoctagon/dashboard.py
+++ b/panoctagon/dashboard.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Any
 
 import dash_mantine_components as dmc
+import networkx as nx
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
@@ -208,6 +209,161 @@ def get_main_data() -> pd.DataFrame:
     return df
 
 
+def get_network_data() -> pd.DataFrame:
+    return pd.read_sql_query(
+        """
+        select
+            a.fighter1_uid,
+            a.fighter2_uid,
+            f1.first_name || ' ' || f1.last_name as fighter1_name,
+            f2.first_name || ' ' || f2.last_name as fighter2_name,
+            count(*) as fight_count
+        from ufc_fights a
+        inner join ufc_fighters f1 on a.fighter1_uid = f1.fighter_uid
+        inner join ufc_fighters f2 on a.fighter2_uid = f2.fighter_uid
+        group by a.fighter1_uid, a.fighter2_uid, fighter1_name, fighter2_name
+        """,
+        get_engine(),
+    )
+
+
+def build_fighter_graph(network_df: pd.DataFrame) -> nx.Graph:
+    G = nx.Graph()
+    for _, row in network_df.iterrows():
+        G.add_edge(
+            row["fighter1_name"],
+            row["fighter2_name"],
+            weight=row["fight_count"],
+        )
+    return G
+
+
+def get_subgraph_for_fighter(G: nx.Graph, fighter_name: str, depth: int = 2) -> nx.Graph:
+    if fighter_name not in G:
+        return nx.Graph()
+
+    nodes = {fighter_name}
+    current_level = {fighter_name}
+
+    for _ in range(depth):
+        next_level = set()
+        for node in current_level:
+            next_level.update(G.neighbors(node))
+        nodes.update(next_level)
+        current_level = next_level
+
+    return G.subgraph(nodes).copy()
+
+
+def create_network_figure(
+    G: nx.Graph, center_fighter: str | None = None, highlight_path: list[str] | None = None
+) -> go.Figure:
+    if len(G.nodes()) == 0:
+        fig = go.Figure()
+        fig.update_layout(
+            annotations=[
+                dict(
+                    text="No connections found",
+                    xref="paper",
+                    yref="paper",
+                    x=0.5,
+                    y=0.5,
+                    showarrow=False,
+                    font=dict(size=20),
+                )
+            ]
+        )
+        return apply_figure_styling(fig)
+
+    pos = nx.spring_layout(G, k=2, iterations=50, seed=42)
+
+    edge_x = []
+    edge_y = []
+    for edge in G.edges():
+        x0, y0 = pos[edge[0]]
+        x1, y1 = pos[edge[1]]
+        edge_x.extend([x0, x1, None])
+        edge_y.extend([y0, y1, None])
+
+    edge_trace = go.Scatter(
+        x=edge_x,
+        y=edge_y,
+        line=dict(width=1, color="#888"),
+        hoverinfo="none",
+        mode="lines",
+    )
+
+    highlight_edge_x = []
+    highlight_edge_y = []
+    if highlight_path and len(highlight_path) > 1:
+        for i in range(len(highlight_path) - 1):
+            if highlight_path[i] in pos and highlight_path[i + 1] in pos:
+                x0, y0 = pos[highlight_path[i]]
+                x1, y1 = pos[highlight_path[i + 1]]
+                highlight_edge_x.extend([x0, x1, None])
+                highlight_edge_y.extend([y0, y1, None])
+
+    highlight_edge_trace = go.Scatter(
+        x=highlight_edge_x,
+        y=highlight_edge_y,
+        line=dict(width=4, color="#ff4444"),
+        hoverinfo="none",
+        mode="lines",
+    )
+
+    node_x = []
+    node_y = []
+    node_text = []
+    node_colors = []
+    node_sizes = []
+
+    path_set = set(highlight_path) if highlight_path else set()
+
+    for node in G.nodes():
+        x, y = pos[node]
+        node_x.append(x)
+        node_y.append(y)
+        node_text.append(node)
+
+        degree = G.degree(node)
+        node_sizes.append(max(15, min(40, 10 + degree * 2)))
+
+        if node == center_fighter:
+            node_colors.append("#ff4444")
+        elif node in path_set:
+            node_colors.append("#ff8888")
+        else:
+            node_colors.append("#1a1a1a")
+
+    node_trace = go.Scatter(
+        x=node_x,
+        y=node_y,
+        mode="markers+text",
+        hoverinfo="text",
+        text=node_text,
+        textposition="top center",
+        textfont=dict(size=10),
+        marker=dict(
+            size=node_sizes,
+            color=node_colors,
+            line=dict(width=2, color="white"),
+        ),
+    )
+
+    fig = go.Figure(data=[edge_trace, highlight_edge_trace, node_trace])
+
+    fig.update_layout(
+        showlegend=False,
+        hovermode="closest",
+        xaxis=dict(showgrid=False, zeroline=False, showticklabels=False, showline=False),
+        yaxis=dict(showgrid=False, zeroline=False, showticklabels=False, showline=False),
+        height=700,
+        margin=dict(l=20, r=20, t=20, b=20),
+    )
+
+    return apply_figure_styling(fig)
+
+
 def get_fighter_list(df: pd.DataFrame) -> list[str]:
     fighter_counts = (
         df.groupby("fighter_name")
@@ -280,6 +436,9 @@ def get_headshot_base64(fighter_uid: str) -> str:
 
 
 df = get_main_data()
+network_df = get_network_data()
+fighter_graph = build_fighter_graph(network_df)
+
 fighter_options = get_fighter_list(df)
 fighter_uid_map = get_fighter_uid_map(df)
 fighter_nickname_map = get_fighter_nickname_map(df)
@@ -295,6 +454,314 @@ most_recent_event = df["event_date"].max().strftime("%Y-%m-%d")
 assets_path = Path(__file__).parent / "assets"
 app = Dash(__name__, assets_folder=str(assets_path))
 server = app.server
+
+fighter_analysis_content = html.Div(
+    [
+        dmc.Group(
+            [
+                html.Img(
+                    id="fighter-headshot",
+                    style={
+                        "width": "237px",
+                        "height": "150px",
+                        "border": "2px solid #1a1a1a",
+                        "borderRadius": "4px",
+                    },
+                ),
+                html.Div(
+                    [
+                        dmc.Select(
+                            label="",
+                            placeholder="Select fighter",
+                            id="fighter-select",
+                            value=initial_fighter,
+                            data=fighter_options,
+                            searchable=True,
+                            clearable=False,
+                            style={"width": "250px"},
+                        ),
+                        dmc.Group(
+                            [
+                                html.Div(
+                                    [
+                                        dmc.Text(
+                                            "Nickname",
+                                            size="xs",
+                                            c="gray",
+                                            style={"height": "14px"},
+                                        ),
+                                        dmc.Text(
+                                            id="fighter-nickname",
+                                            size="sm",
+                                            style={"minHeight": "18px"},
+                                        ),
+                                    ]
+                                ),
+                                html.Div(
+                                    [
+                                        dmc.Text(
+                                            "Stance",
+                                            size="xs",
+                                            c="gray",
+                                            style={"height": "14px"},
+                                        ),
+                                        dmc.Text(
+                                            id="fighter-stance",
+                                            size="sm",
+                                            style={"minHeight": "18px"},
+                                        ),
+                                    ]
+                                ),
+                                html.Div(
+                                    [
+                                        dmc.Text(
+                                            "Style",
+                                            size="xs",
+                                            c="gray",
+                                            style={"height": "14px"},
+                                        ),
+                                        dmc.Text(
+                                            id="fighter-style",
+                                            size="sm",
+                                            style={"minHeight": "18px"},
+                                        ),
+                                    ]
+                                ),
+                            ],
+                            gap="md",
+                            mt="md",
+                        ),
+                    ]
+                ),
+            ],
+            align="flex-start",
+            gap="lg",
+            mb="md",
+        ),
+        dmc.Tabs(
+            [
+                dmc.TabsList(
+                    [
+                        dmc.TabsTab(
+                            "Fighter Profile",
+                            value="profile",
+                        ),
+                        dmc.TabsTab("Fight History", value="history"),
+                        dmc.TabsTab(
+                            "Striking Analytics",
+                            value="striking",
+                        ),
+                    ]
+                ),
+                dmc.TabsPanel(
+                    [
+                        dmc.SimpleGrid(
+                            [
+                                dmc.Card(
+                                    [
+                                        dmc.Text(
+                                            "Total Fights",
+                                            size="sm",
+                                            c="gray",
+                                        ),
+                                        dmc.Title(
+                                            id="total-fights",
+                                            order=2,
+                                        ),
+                                    ],
+                                    shadow="sm",
+                                    withBorder=True,
+                                    p="lg",
+                                ),
+                                dmc.Card(
+                                    [
+                                        dmc.Text(
+                                            "Record",
+                                            size="sm",
+                                            c="gray",
+                                        ),
+                                        dmc.Title(
+                                            id="record",
+                                            order=2,
+                                        ),
+                                    ],
+                                    shadow="sm",
+                                    withBorder=True,
+                                    p="lg",
+                                ),
+                                dmc.Card(
+                                    [
+                                        dmc.Text(
+                                            "Finish Rate",
+                                            size="sm",
+                                            c="gray",
+                                        ),
+                                        dmc.Title(
+                                            id="finish-rate",
+                                            order=2,
+                                        ),
+                                    ],
+                                    shadow="sm",
+                                    withBorder=True,
+                                    p="lg",
+                                ),
+                                dmc.Card(
+                                    [
+                                        dmc.Text(
+                                            "Strikes Landed",
+                                            size="sm",
+                                            c="gray",
+                                        ),
+                                        dmc.Title(
+                                            id="strikes-landed",
+                                            order=2,
+                                        ),
+                                    ],
+                                    shadow="sm",
+                                    withBorder=True,
+                                    p="lg",
+                                ),
+                                dmc.Card(
+                                    [
+                                        dmc.Text(
+                                            "Strikes Absorbed",
+                                            size="sm",
+                                            c="gray",
+                                        ),
+                                        dmc.Title(
+                                            id="strikes-absorbed",
+                                            order=2,
+                                        ),
+                                    ],
+                                    shadow="sm",
+                                    withBorder=True,
+                                    p="lg",
+                                ),
+                            ],
+                            cols=5,
+                            spacing="md",
+                            mb="md",
+                        ),
+                        create_plot_with_title(
+                            "Career Timeline",
+                            "career-timeline",
+                            margin_bottom=True,
+                        ),
+                        create_plot_with_title(
+                            "Fight Outcome Distribution",
+                            "win-method-chart",
+                        ),
+                    ],
+                    value="profile",
+                    pt="md",
+                ),
+                dmc.TabsPanel(
+                    dash_table.DataTable(
+                        id="fight-history-table",
+                        columns=[],
+                        data=[],
+                        sort_action="native",
+                        filter_action="native",
+                        style_table={
+                            "height": "800px",
+                            "overflowY": "scroll",
+                        },
+                        style_data={
+                            "border": "none",
+                        },
+                        style_cell_conditional=[
+                            {
+                                "if": {"column_id": ""},
+                                "width": "40px",
+                                "textAlign": "center",
+                            },
+                        ],
+                        style_data_conditional=[],
+                        style_header={
+                            "backgroundColor": "#e9ecef",
+                            "fontWeight": "bold",
+                            "border": "none",
+                        },
+                    ),
+                    value="history",
+                    pt="md",
+                ),
+                dmc.TabsPanel(
+                    [
+                        create_plot_with_title(
+                            "Striking Accuracy Over Time",
+                            "accuracy-trend",
+                            margin_bottom=True,
+                        ),
+                        create_plot_with_title(
+                            "Strike Target Distribution",
+                            "target-distribution",
+                            margin_bottom=True,
+                        ),
+                        create_plot_with_title(
+                            "Strikes Landed vs Absorbed",
+                            "strikes-comparison",
+                        ),
+                    ],
+                    value="striking",
+                    pt="md",
+                ),
+            ],
+            value="profile",
+            id="main-tabs",
+        ),
+    ]
+)
+
+fighter_network_content = html.Div(
+    [
+        dmc.Group(
+            [
+                dmc.Select(
+                    label="Center Fighter",
+                    placeholder="Select a fighter to center the graph",
+                    id="network-fighter-select",
+                    data=fighter_options,
+                    searchable=True,
+                    clearable=True,
+                    style={"width": "250px"},
+                ),
+                dmc.Select(
+                    label="Find Path To",
+                    placeholder="Select second fighter",
+                    id="network-fighter-target",
+                    data=fighter_options,
+                    searchable=True,
+                    clearable=True,
+                    style={"width": "250px"},
+                ),
+                dmc.NumberInput(
+                    label="Connection Depth",
+                    id="network-depth",
+                    value=2,
+                    min=1,
+                    max=4,
+                    style={"width": "150px"},
+                ),
+            ],
+            align="flex-end",
+            gap="md",
+            mb="md",
+        ),
+        html.Div(
+            id="network-path-info",
+            style={"marginBottom": "1rem"},
+        ),
+        html.Div(
+            dcc.Graph(
+                id="fighter-network-graph",
+                figure={},
+                config={"displayModeBar": False},
+            ),
+            className="plot-container-wrapper",
+        ),
+    ]
+)
 
 app.layout = dmc.MantineProvider(
     html.Div(
@@ -318,261 +785,28 @@ app.layout = dmc.MantineProvider(
                 ),
                 dmc.AppShellMain(
                     dmc.Container(
-                        [
-                            dmc.Group(
-                                [
-                                    html.Img(
-                                        id="fighter-headshot",
-                                        style={
-                                            "width": "237px",
-                                            "height": "150px",
-                                            "border": "2px solid #1a1a1a",
-                                            "borderRadius": "4px",
-                                        },
-                                    ),
-                                    html.Div(
-                                        [
-                                            dmc.Select(
-                                                label="",
-                                                placeholder="Select fighter",
-                                                id="fighter-select",
-                                                value=initial_fighter,
-                                                data=fighter_options,
-                                                searchable=True,
-                                                clearable=False,
-                                                style={"width": "250px"},
-                                            ),
-                                            dmc.Group(
-                                                [
-                                                    html.Div(
-                                                        [
-                                                            dmc.Text(
-                                                                "Nickname",
-                                                                size="xs",
-                                                                c="gray",
-                                                                style={"height": "14px"},
-                                                            ),
-                                                            dmc.Text(
-                                                                id="fighter-nickname",
-                                                                size="sm",
-                                                                style={"minHeight": "18px"},
-                                                            ),
-                                                        ]
-                                                    ),
-                                                    html.Div(
-                                                        [
-                                                            dmc.Text(
-                                                                "Stance",
-                                                                size="xs",
-                                                                c="gray",
-                                                                style={"height": "14px"},
-                                                            ),
-                                                            dmc.Text(
-                                                                id="fighter-stance",
-                                                                size="sm",
-                                                                style={"minHeight": "18px"},
-                                                            ),
-                                                        ]
-                                                    ),
-                                                    html.Div(
-                                                        [
-                                                            dmc.Text(
-                                                                "Style",
-                                                                size="xs",
-                                                                c="gray",
-                                                                style={"height": "14px"},
-                                                            ),
-                                                            dmc.Text(
-                                                                id="fighter-style",
-                                                                size="sm",
-                                                                style={"minHeight": "18px"},
-                                                            ),
-                                                        ]
-                                                    ),
-                                                ],
-                                                gap="md",
-                                                mt="md",
-                                            ),
-                                        ]
-                                    ),
-                                ],
-                                align="flex-start",
-                                gap="lg",
-                                mb="md",
-                            ),
-                            dmc.Tabs(
-                                [
-                                    dmc.TabsList(
-                                        [
-                                            dmc.TabsTab(
-                                                "Fighter Profile",
-                                                value="profile",
-                                            ),
-                                            dmc.TabsTab("Fight History", value="history"),
-                                            dmc.TabsTab(
-                                                "Striking Analytics",
-                                                value="striking",
-                                            ),
-                                        ]
-                                    ),
-                                    dmc.TabsPanel(
-                                        [
-                                            dmc.SimpleGrid(
-                                                [
-                                                    dmc.Card(
-                                                        [
-                                                            dmc.Text(
-                                                                "Total Fights",
-                                                                size="sm",
-                                                                c="gray",
-                                                            ),
-                                                            dmc.Title(
-                                                                id="total-fights",
-                                                                order=2,
-                                                            ),
-                                                        ],
-                                                        shadow="sm",
-                                                        withBorder=True,
-                                                        p="lg",
-                                                    ),
-                                                    dmc.Card(
-                                                        [
-                                                            dmc.Text(
-                                                                "Record",
-                                                                size="sm",
-                                                                c="gray",
-                                                            ),
-                                                            dmc.Title(
-                                                                id="record",
-                                                                order=2,
-                                                            ),
-                                                        ],
-                                                        shadow="sm",
-                                                        withBorder=True,
-                                                        p="lg",
-                                                    ),
-                                                    dmc.Card(
-                                                        [
-                                                            dmc.Text(
-                                                                "Finish Rate",
-                                                                size="sm",
-                                                                c="gray",
-                                                            ),
-                                                            dmc.Title(
-                                                                id="finish-rate",
-                                                                order=2,
-                                                            ),
-                                                        ],
-                                                        shadow="sm",
-                                                        withBorder=True,
-                                                        p="lg",
-                                                    ),
-                                                    dmc.Card(
-                                                        [
-                                                            dmc.Text(
-                                                                "Strikes Landed",
-                                                                size="sm",
-                                                                c="gray",
-                                                            ),
-                                                            dmc.Title(
-                                                                id="strikes-landed",
-                                                                order=2,
-                                                            ),
-                                                        ],
-                                                        shadow="sm",
-                                                        withBorder=True,
-                                                        p="lg",
-                                                    ),
-                                                    dmc.Card(
-                                                        [
-                                                            dmc.Text(
-                                                                "Strikes Absorbed",
-                                                                size="sm",
-                                                                c="gray",
-                                                            ),
-                                                            dmc.Title(
-                                                                id="strikes-absorbed",
-                                                                order=2,
-                                                            ),
-                                                        ],
-                                                        shadow="sm",
-                                                        withBorder=True,
-                                                        p="lg",
-                                                    ),
-                                                ],
-                                                cols=5,
-                                                spacing="md",
-                                                mb="md",
-                                            ),
-                                            create_plot_with_title(
-                                                "Career Timeline",
-                                                "career-timeline",
-                                                margin_bottom=True,
-                                            ),
-                                            create_plot_with_title(
-                                                "Fight Outcome Distribution",
-                                                "win-method-chart",
-                                            ),
-                                        ],
-                                        value="profile",
-                                        pt="md",
-                                    ),
-                                    dmc.TabsPanel(
-                                        dash_table.DataTable(
-                                            id="fight-history-table",
-                                            columns=[],
-                                            data=[],
-                                            sort_action="native",
-                                            filter_action="native",
-                                            style_table={
-                                                "height": "800px",
-                                                "overflowY": "scroll",
-                                            },
-                                            style_data={
-                                                "border": "none",
-                                            },
-                                            style_cell_conditional=[
-                                                {
-                                                    "if": {"column_id": ""},
-                                                    "width": "40px",
-                                                    "textAlign": "center",
-                                                },
-                                            ],
-                                            style_data_conditional=[],
-                                            style_header={
-                                                "backgroundColor": "#e9ecef",
-                                                "fontWeight": "bold",
-                                                "border": "none",
-                                            },
-                                        ),
-                                        value="history",
-                                        pt="md",
-                                    ),
-                                    dmc.TabsPanel(
-                                        [
-                                            create_plot_with_title(
-                                                "Striking Accuracy Over Time",
-                                                "accuracy-trend",
-                                                margin_bottom=True,
-                                            ),
-                                            create_plot_with_title(
-                                                "Strike Target Distribution",
-                                                "target-distribution",
-                                                margin_bottom=True,
-                                            ),
-                                            create_plot_with_title(
-                                                "Strikes Landed vs Absorbed",
-                                                "strikes-comparison",
-                                            ),
-                                        ],
-                                        value="striking",
-                                        pt="md",
-                                    ),
-                                ],
-                                value="profile",
-                                id="main-tabs",
-                            ),
-                        ],
+                        dmc.Tabs(
+                            [
+                                dmc.TabsList(
+                                    [
+                                        dmc.TabsTab("Fighter Analysis", value="analysis"),
+                                        dmc.TabsTab("Fighter Network", value="network"),
+                                    ]
+                                ),
+                                dmc.TabsPanel(
+                                    fighter_analysis_content,
+                                    value="analysis",
+                                    pt="md",
+                                ),
+                                dmc.TabsPanel(
+                                    fighter_network_content,
+                                    value="network",
+                                    pt="md",
+                                ),
+                            ],
+                            value="analysis",
+                            id="top-level-tabs",
+                        ),
                         size="xl",
                         p="md",
                     )
@@ -1090,6 +1324,65 @@ def update_strikes_comparison(fighter: str):
         )
 
     return apply_figure_styling(fig)
+
+
+@callback(
+    [
+        Output("fighter-network-graph", "figure"),
+        Output("network-path-info", "children"),
+    ],
+    [
+        Input("network-fighter-select", "value"),
+        Input("network-fighter-target", "value"),
+        Input("network-depth", "value"),
+    ],
+)
+def update_network_graph(center_fighter: str | None, target_fighter: str | None, depth: int):
+    if not center_fighter:
+        fig = create_network_figure(nx.Graph())
+        return fig, ""
+
+    subgraph = get_subgraph_for_fighter(fighter_graph, center_fighter, depth)
+
+    highlight_path = None
+    path_info = ""
+
+    if target_fighter and target_fighter != center_fighter:
+        if target_fighter in fighter_graph:
+            try:
+                path = nx.shortest_path(fighter_graph, center_fighter, target_fighter)
+                highlight_path = path
+                path_length = len(path) - 1
+                path_str = " -> ".join(path)
+                path_info = dmc.Alert(
+                    [
+                        dmc.Text(f"Shortest path ({path_length} fights): ", fw=700, span=True),
+                        dmc.Text(path_str, span=True),
+                    ],
+                    color="blue",
+                    variant="light",
+                )
+                for node in path:
+                    if node not in subgraph:
+                        subgraph = fighter_graph.subgraph(
+                            set(subgraph.nodes()) | set(path)
+                        ).copy()
+                        break
+            except nx.NetworkXNoPath:
+                path_info = dmc.Alert(
+                    f"No path found between {center_fighter} and {target_fighter}",
+                    color="red",
+                    variant="light",
+                )
+        else:
+            path_info = dmc.Alert(
+                f"{target_fighter} not found in the network",
+                color="orange",
+                variant="light",
+            )
+
+    fig = create_network_figure(subgraph, center_fighter, highlight_path)
+    return fig, path_info
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "duckdb-engine==0.13.2",
     "dbt-duckdb==1.9.0",
     "dagster-dg-cli>=1.12.12",
+    "networkx==3.4.2",
 ]
 
 [tool.pyright]


### PR DESCRIPTION
Add a new top-level "Fighter Network" tab that displays an interactive
graph showing connections between fighters based on who they've fought.
Features include:
- Select a center fighter to view their network neighborhood
- Configurable connection depth (1-4 degrees of separation)
- Path finding between two fighters with highlighted shortest path
- Node sizes based on number of connections