### PR TITLE
feat: add FastAPI-based fight data CLI

### DIFF
--- a/panoctagon/admin.py
+++ b/panoctagon/admin.py
@@ -1,0 +1,29 @@
+import typer
+
+import panoctagon.one.one as one
+import panoctagon.ufc.app as ufc
+
+app = typer.Typer(pretty_exceptions_enable=False)
+app.add_typer(ufc.app, name="ufc")
+app.add_typer(one.app, name="one")
+
+
+@app.command()
+def serve(
+    host: str = typer.Option("127.0.0.1", "--host", "-h", help="Host to bind to"),
+    port: int = typer.Option(8000, "--port", "-p", help="Port to bind to"),
+    reload: bool = typer.Option(False, "--reload", "-r", help="Enable auto-reload"),
+) -> None:
+    """Start the Panoctagon API server."""
+    import uvicorn
+
+    uvicorn.run(
+        "panoctagon.api.server:app",
+        host=host,
+        port=port,
+        reload=reload,
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/panoctagon/api/cli.py
+++ b/panoctagon/api/cli.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import json
+from enum import Enum
+from typing import Any, Optional
+
+import httpx
+import typer
+
+app = typer.Typer(
+    name="data",
+    help="Query UFC fight data from the API",
+    pretty_exceptions_enable=False,
+)
+
+DEFAULT_API_URL = "http://localhost:8000"
+
+
+class OutputFormat(str, Enum):
+    json = "json"
+    table = "table"
+
+
+def get_api_url() -> str:
+    import os
+
+    return os.environ.get("PANOCTAGON_API_URL", DEFAULT_API_URL)
+
+
+def format_table(data: list[dict[str, Any]], columns: Optional[list[str]] = None) -> str:
+    if not data:
+        return "No data found."
+
+    if columns:
+        data = [{k: row.get(k) for k in columns} for row in data]
+
+    headers = list(data[0].keys())
+
+    col_widths = {}
+    for header in headers:
+        max_width = len(str(header))
+        for row in data:
+            val = row.get(header)
+            val_str = "-" if val is None else str(val)
+            max_width = max(max_width, len(val_str))
+        col_widths[header] = min(max_width, 40)
+
+    header_row = "| " + " | ".join(str(h).ljust(col_widths[h]) for h in headers) + " |"
+    separator = "|-" + "-|-".join("-" * col_widths[h] for h in headers) + "-|"
+
+    rows = []
+    for row in data:
+        cells = []
+        for h in headers:
+            val = row.get(h)
+            val_str = "-" if val is None else str(val)
+            if len(val_str) > 40:
+                val_str = val_str[:37] + "..."
+            cells.append(val_str.ljust(col_widths[h]))
+        rows.append("| " + " | ".join(cells) + " |")
+
+    return "\n".join([header_row, separator] + rows)
+
+
+def format_output(data: Any, fmt: OutputFormat, columns: Optional[list[str]] = None) -> str:
+    if fmt == OutputFormat.json:
+        return json.dumps(data, indent=2, default=str)
+
+    if isinstance(data, list):
+        return format_table(data, columns)
+    elif isinstance(data, dict):
+        return format_table([data], columns)
+    else:
+        return str(data)
+
+
+def api_request(endpoint: str, params: Optional[dict[str, Any]] = None) -> Any:
+    url = f"{get_api_url()}{endpoint}"
+    params = {k: v for k, v in (params or {}).items() if v is not None}
+
+    try:
+        response = httpx.get(url, params=params, timeout=30.0)
+        response.raise_for_status()
+        return response.json()
+    except httpx.ConnectError:
+        typer.echo(f"Error: Could not connect to API at {get_api_url()}", err=True)
+        typer.echo("Make sure the API server is running: uv run panoctagon serve", err=True)
+        raise typer.Exit(1)
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            detail = e.response.json().get("detail", "Not found")
+            typer.echo(f"Error: {detail}", err=True)
+        else:
+            typer.echo(f"Error: {e.response.status_code} - {e.response.text}", err=True)
+        raise typer.Exit(1)
+
+
+@app.command("fighter")
+def fighter_search(
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Search by fighter name"),
+    division: Optional[str] = typer.Option(None, "--division", "-d", help="Filter by weight class"),
+    limit: int = typer.Option(20, "--limit", "-l", help="Maximum results"),
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """Search for fighters by name or division."""
+    data = api_request("/fighter", {"name": name, "division": division, "limit": limit})
+    columns = ["full_name", "nickname", "stance", "division", "wins", "losses", "draws"]
+    typer.echo(format_output(data, fmt, columns))
+
+
+@app.command("fighter-detail")
+def fighter_detail(
+    fighter_uid: str = typer.Argument(..., help="Fighter UID"),
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """Get detailed information about a specific fighter."""
+    data = api_request(f"/fighter/{fighter_uid}")
+
+    if fmt == OutputFormat.json:
+        typer.echo(format_output(data, fmt))
+        return
+
+    bio = data["bio"]
+    record = data["record"]
+    fights = data["recent_fights"]
+
+    typer.echo(f"\n{bio['full_name']}")
+    if bio.get("nickname"):
+        typer.echo(f'"{bio["nickname"]}"')
+    typer.echo("-" * 40)
+
+    typer.echo(f"Record: {record['wins']}-{record['losses']}-{record['draws']}")
+    if record.get("no_contests"):
+        typer.echo(f"No Contests: {record['no_contests']}")
+
+    typer.echo(f"\nStance: {bio.get('stance') or '-'}")
+    typer.echo(f"Height: {bio.get('height_inches') or '-'} in")
+    typer.echo(f"Reach: {bio.get('reach_inches') or '-'} in")
+    if bio.get("dob"):
+        typer.echo(f"DOB: {bio['dob']}")
+    if bio.get("place_of_birth"):
+        typer.echo(f"From: {bio['place_of_birth']}")
+
+    if fights:
+        typer.echo("\nRecent Fights:")
+        typer.echo("-" * 40)
+        columns = ["event_date", "opponent_name", "result", "decision"]
+        typer.echo(format_table(fights, columns))
+
+
+@app.command("upcoming")
+def upcoming_fights(
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """List upcoming UFC events and matchups."""
+    data = api_request("/upcoming")
+
+    if fmt == OutputFormat.json:
+        typer.echo(format_output(data, fmt))
+        return
+
+    if not data:
+        typer.echo("No upcoming events found.")
+        return
+
+    for event in data:
+        typer.echo(f"\n{event['event_title']}")
+        typer.echo(f"{event['event_date']} - {event['event_location']}")
+        typer.echo("=" * 60)
+
+        for fight in event["fights"]:
+            division = fight.get("fight_division") or "TBD"
+            division = division.replace("_", " ").title() if division else "TBD"
+            fight_type = " [TITLE]" if fight.get("fight_type") and "title" in fight["fight_type"].lower() else ""
+
+            typer.echo(f"\n{division}{fight_type}")
+            f1 = f"{fight['fighter1_name']} ({fight['fighter1_record']})"
+            f2 = f"{fight['fighter2_name']} ({fight['fighter2_record']})"
+            typer.echo(f"  {f1}")
+            typer.echo(f"    vs")
+            typer.echo(f"  {f2}")
+
+
+@app.command("rankings")
+def rankings(
+    division: Optional[str] = typer.Option(None, "--division", "-d", help="Filter by weight class"),
+    min_fights: int = typer.Option(5, "--min-fights", "-m", help="Minimum UFC fights"),
+    limit: int = typer.Option(15, "--limit", "-l", help="Top N per division"),
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """Show fighter rankings by win rate within each division."""
+    data = api_request("/rankings", {"division": division, "min_fights": min_fights, "limit": limit})
+
+    if fmt == OutputFormat.json:
+        typer.echo(format_output(data, fmt))
+        return
+
+    if not data:
+        typer.echo("No rankings found.")
+        return
+
+    current_division = None
+    for fighter in data:
+        if fighter["division"] != current_division:
+            current_division = fighter["division"]
+            div_display = current_division.replace("_", " ").title() if current_division else "Unknown"
+            typer.echo(f"\n{div_display}")
+            typer.echo("-" * 50)
+            typer.echo(f"{'Rank':<5} {'Fighter':<25} {'Record':<12} {'Win%':<6}")
+            typer.echo("-" * 50)
+
+        record = f"{fighter['wins']}-{fighter['losses']}-{fighter['draws']}"
+        typer.echo(f"{fighter['rank']:<5} {fighter['full_name']:<25} {record:<12} {fighter['win_rate']:<6.1f}")
+
+
+@app.command("roster")
+def roster(
+    stance: Optional[str] = typer.Option(None, "--stance", "-s", help="Filter by stance"),
+    division: Optional[str] = typer.Option(None, "--division", "-d", help="Filter by weight class"),
+    min_fights: int = typer.Option(5, "--min-fights", "-m", help="Minimum UFC fights"),
+    min_win_rate: Optional[float] = typer.Option(None, "--min-win-rate", help="Minimum win rate %"),
+    max_win_rate: Optional[float] = typer.Option(None, "--max-win-rate", help="Maximum win rate %"),
+    limit: int = typer.Option(50, "--limit", "-l", help="Maximum results"),
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """Search the UFC roster with filters for stance, division, and statistics."""
+    data = api_request(
+        "/roster",
+        {
+            "stance": stance,
+            "division": division,
+            "min_fights": min_fights,
+            "min_win_rate": min_win_rate,
+            "max_win_rate": max_win_rate,
+            "limit": limit,
+        },
+    )
+    columns = [
+        "full_name",
+        "stance",
+        "division",
+        "wins",
+        "losses",
+        "win_rate",
+        "avg_strikes_landed",
+        "avg_strikes_absorbed",
+    ]
+    typer.echo(format_output(data, fmt, columns))
+
+
+@app.command("events")
+def events(
+    upcoming_only: bool = typer.Option(False, "--upcoming", "-u", help="Only show upcoming events"),
+    limit: int = typer.Option(20, "--limit", "-l", help="Maximum events"),
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """List UFC events."""
+    data = api_request("/events", {"upcoming_only": upcoming_only, "limit": limit})
+    columns = ["title", "event_date", "event_location", "num_fights"]
+    typer.echo(format_output(data, fmt, columns))
+
+
+@app.command("fight")
+def fight_detail(
+    fight_uid: str = typer.Argument(..., help="Fight UID"),
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """Get detailed statistics for a specific fight."""
+    data = api_request(f"/fight/{fight_uid}")
+
+    if fmt == OutputFormat.json:
+        typer.echo(format_output(data, fmt))
+        return
+
+    typer.echo(f"\n{data['event_title']} - {data['event_date']}")
+    division = data.get("fight_division") or "Unknown"
+    division = division.replace("_", " ").title() if division else "Unknown"
+    typer.echo(f"{division}")
+    typer.echo("=" * 60)
+
+    f1 = data["fighter1"]
+    f2 = data["fighter2"]
+
+    typer.echo(f"\n{f1['fighter_name']} ({f1['result'] or 'TBD'}) vs {f2['fighter_name']} ({f2['result'] or 'TBD'})")
+
+    if data.get("decision"):
+        typer.echo(f"Result: {data['decision']}")
+        if data.get("decision_round"):
+            typer.echo(f"Round: {data['decision_round']}")
+
+    if f1["rounds"] or f2["rounds"]:
+        typer.echo("\nRound-by-Round Stats:")
+        typer.echo("-" * 60)
+
+        max_rounds = max(len(f1["rounds"]), len(f2["rounds"]))
+        for r in range(max_rounds):
+            typer.echo(f"\nRound {r + 1}:")
+            for fighter in [f1, f2]:
+                if r < len(fighter["rounds"]):
+                    rd = fighter["rounds"][r]
+                    strikes = f"{rd.get('total_strikes_landed') or 0}/{rd.get('total_strikes_attempted') or 0}"
+                    tds = f"{rd.get('takedowns_landed') or 0}/{rd.get('takedowns_attempted') or 0}"
+                    ctrl = rd.get("control_time_seconds") or 0
+                    ctrl_str = f"{ctrl // 60}:{ctrl % 60:02d}" if ctrl else "-"
+                    typer.echo(f"  {fighter['fighter_name']}: Strikes {strikes}, TD {tds}, Ctrl {ctrl_str}")
+
+
+if __name__ == "__main__":
+    app()

--- a/panoctagon/api/cli.py
+++ b/panoctagon/api/cli.py
@@ -9,6 +9,8 @@ import httpx
 import questionary
 import typer
 
+from panoctagon.enums import format_decision, format_division
+
 DEFAULT_API_URL = "http://localhost:8000"
 
 
@@ -243,12 +245,6 @@ def api_request(endpoint: str, params: Optional[dict[str, Any]] = None) -> Any:
         raise typer.Exit(1)
 
 
-def format_division(div: Optional[str]) -> str:
-    if not div:
-        return "Unknown"
-    return div.replace("_", " ").title()
-
-
 def upcoming_impl(fmt: OutputFormat) -> None:
     data = api_request("/upcoming")
 
@@ -434,7 +430,7 @@ def fighter_impl(name: str, fmt: OutputFormat, history_limit: Optional[int] = No
                     "date": fight.get("event_date"),
                     "opponent": f"[bold]{fight.get('opponent_name')}[/bold]",
                     "result": result_style,
-                    "decision": decision,
+                    "decision": format_decision(decision),
                     "round": rd,
                 }
             )
@@ -654,7 +650,7 @@ def roster_impl(
             {
                 "name": record["full_name"],
                 "stance": record["stance"],
-                "division": record["division"].replace("_", " ").title(),
+                "division": format_division(record["division"]),
                 "wins": record["wins"],
                 "losses": record["losses"],
                 "win rate": record["win_rate"],

--- a/panoctagon/api/cli.py
+++ b/panoctagon/api/cli.py
@@ -55,7 +55,7 @@ def is_interactive() -> bool:
     return sys.stdin.isatty() and sys.stdout.isatty()
 
 
-def select_fighter(name: str, prompt: Optional[str] = None) -> dict[str, Any]:
+def select_fighter(name: str | None, prompt: Optional[str] = None) -> dict[str, Any]:
     fighters = api_request("/fighter", {"name": name, "limit": 20})
 
     if not fighters:
@@ -68,7 +68,11 @@ def select_fighter(name: str, prompt: Optional[str] = None) -> dict[str, Any]:
     if not is_interactive():
         return fighters[0]
 
-    prompt_text = prompt or f"Multiple fighters match '{name}'. Select one:"
+    if name is not None:
+        prompt_text = prompt or f"Multiple fighters match '{name}'. Select one:"
+    else:
+        prompt_text = prompt or "Select a fighter"
+
     choices = []
     for f in fighters:
         record = f"{f['wins']}-{f['losses']}-{f['draws']}"

--- a/panoctagon/api/cli.py
+++ b/panoctagon/api/cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
-from enum import Enum
+from enum import Enum, StrEnum, auto
 from typing import Any, Optional
 
 import httpx
@@ -27,6 +27,22 @@ class SortBy(str, Enum):
     sub_wins = "sub_wins"
     opp_win_rate = "opp_win_rate"
     full_name = "full_name"
+
+
+class Division(StrEnum):
+    LIGHTWEIGHT = auto()
+    WELTERWEIGHT = auto()
+    MIDDLEWEIGHT = auto()
+    LIGHT_HEAVYWEIGHT = auto()
+    HEAVYWEIGHT = auto()
+    FLYWEIGHT = auto()
+    BANTAMWEIGHT = auto()
+    FEATHERWEIGHT = auto()
+    STRAWWEIGHT = auto()
+    WOMENS_STRAWWEIGHT = auto()
+    WOMENS_FLYWEIGHT = auto()
+    WOMENS_BANTAMWEIGHT = auto()
+    WOMENS_FEATHERWEIGHT = auto()
 
 
 def get_api_url() -> str:
@@ -135,7 +151,7 @@ def select_fight_from_fighter(fighter: dict[str, Any]) -> dict[str, Any]:
     return selected
 
 
-def select_division() -> str:
+def select_division() -> Division:
     divisions = api_request("/divisions")
 
     if not divisions:
@@ -157,7 +173,7 @@ def select_division() -> str:
     if selected is None:
         raise typer.Exit(0)
 
-    return selected
+    return Division(selected)
 
 
 def format_table(data: list[dict[str, Any]], columns: Optional[list[str]] = None) -> str:
@@ -266,7 +282,7 @@ def upcoming_impl(fmt: OutputFormat) -> None:
 
 
 def leaderboard_impl(
-    division: Optional[str],
+    division: Division | None,
     min_fights: int,
     limit: int,
     fmt: OutputFormat,
@@ -605,7 +621,7 @@ def event_impl(name: Optional[str], upcoming_only: bool, limit: int, fmt: Output
 
 
 def roster_impl(
-    division: Optional[str],
+    division: Division | None,
     min_fights: int,
     min_win_rate: Optional[float],
     max_win_rate: Optional[float],

--- a/panoctagon/api/cli.py
+++ b/panoctagon/api/cli.py
@@ -276,20 +276,32 @@ def rankings_impl(
         typer.echo("No rankings found.")
         return
 
+    excluded_divisions = {"catch_weight", "open_weight"}
+    data = [f for f in data if f.get("division") not in excluded_divisions]
+
     current_division = None
+    rows: list[dict[str, Any]] = []
     for fighter in data:
         if fighter["division"] != current_division:
+            if rows:
+                typer.echo(format_table(rows))
             current_division = fighter["division"]
             div_display = format_division(current_division)
             typer.echo(f"\n{div_display}")
-            typer.echo("-" * 50)
-            typer.echo(f"{'Rank':<5} {'Fighter':<25} {'Record':<12} {'Win%':<6}")
-            typer.echo("-" * 50)
+            rows = []
 
         record = f"{fighter['wins']}-{fighter['losses']}-{fighter['draws']}"
-        typer.echo(
-            f"{fighter['rank']:<5} {fighter['full_name']:<25} {record:<12} {fighter['win_rate']:<6.1f}"
+        rows.append(
+            {
+                "rank": fighter["rank"],
+                "fighter": f"[bold]{fighter['full_name']}[/bold]",
+                "record": record,
+                "win%": f"{fighter['win_rate']:.1f}",
+            }
         )
+
+    if rows:
+        typer.echo(format_table(rows))
 
 
 def search_impl(name: str, division: Optional[str], limit: int, fmt: OutputFormat) -> None:

--- a/panoctagon/api/cli.py
+++ b/panoctagon/api/cli.py
@@ -133,10 +133,7 @@ def select_division() -> str:
     if not is_interactive():
         return divisions[0]
 
-    choices = [
-        questionary.Choice(title=format_division(d), value=d)
-        for d in divisions
-    ]
+    choices = [questionary.Choice(title=format_division(d), value=d) for d in divisions]
 
     selected = questionary.select(
         "Select a division:",
@@ -243,21 +240,33 @@ def upcoming_impl(fmt: OutputFormat) -> None:
 
         for fight in event["fights"]:
             division = format_division(fight.get("fight_division"))
-            fight_type = " [TITLE]" if fight.get("fight_type") and "title" in fight["fight_type"].lower() else ""
+            fight_type = (
+                " [TITLE]"
+                if fight.get("fight_type") and "title" in fight["fight_type"].lower()
+                else ""
+            )
 
             typer.echo(f"\n{division}{fight_type}")
             f1 = f"{fight['fighter1_name']} ({fight['fighter1_record']})"
             f2 = f"{fight['fighter2_name']} ({fight['fighter2_record']})"
             typer.echo(f"  {f1}")
-            typer.echo(f"    vs")
+            typer.echo("    vs")
             typer.echo(f"  {f2}")
 
 
-def rankings_impl(division: Optional[str], min_fights: int, limit: int, fmt: OutputFormat, interactive: bool = False) -> None:
+def rankings_impl(
+    division: Optional[str],
+    min_fights: int,
+    limit: int,
+    fmt: OutputFormat,
+    interactive: bool = False,
+) -> None:
     if interactive and division is None and is_interactive():
         division = select_division()
 
-    data = api_request("/rankings", {"division": division, "min_fights": min_fights, "limit": limit})
+    data = api_request(
+        "/rankings", {"division": division, "min_fights": min_fights, "limit": limit}
+    )
 
     if fmt == OutputFormat.json:
         typer.echo(format_output(data, fmt))
@@ -278,7 +287,9 @@ def rankings_impl(division: Optional[str], min_fights: int, limit: int, fmt: Out
             typer.echo("-" * 50)
 
         record = f"{fighter['wins']}-{fighter['losses']}-{fighter['draws']}"
-        typer.echo(f"{fighter['rank']:<5} {fighter['full_name']:<25} {record:<12} {fighter['win_rate']:<6.1f}")
+        typer.echo(
+            f"{fighter['rank']:<5} {fighter['full_name']:<25} {record:<12} {fighter['win_rate']:<6.1f}"
+        )
 
 
 def search_impl(name: str, division: Optional[str], limit: int, fmt: OutputFormat) -> None:
@@ -378,15 +389,17 @@ def compare_impl(fighter1: str, fighter2: str, fmt: OutputFormat) -> None:
     f2_detail = api_request(f"/fighter/{f2['fighter_uid']}")
 
     if fmt == OutputFormat.json:
-        typer.echo(json.dumps({"fighter1": f1_detail, "fighter2": f2_detail}, indent=2, default=str))
+        typer.echo(
+            json.dumps({"fighter1": f1_detail, "fighter2": f2_detail}, indent=2, default=str)
+        )
         return
 
     b1, r1 = f1_detail["bio"], f1_detail["record"]
     b2, r2 = f2_detail["bio"], f2_detail["record"]
 
-    typer.echo(f"\n{'='*60}")
+    typer.echo(f"\n{'=' * 60}")
     typer.echo(f"{'TALE OF THE TAPE':^60}")
-    typer.echo(f"{'='*60}")
+    typer.echo(f"{'=' * 60}")
 
     def compare_row(label: str, v1: Any, v2: Any) -> None:
         v1_str = str(v1) if v1 is not None else "-"
@@ -394,16 +407,24 @@ def compare_impl(fighter1: str, fighter2: str, fmt: OutputFormat) -> None:
         typer.echo(f"{v1_str:>25}  {label:^8}  {v2_str:<25}")
 
     compare_row("NAME", b1["full_name"], b2["full_name"])
-    compare_row("RECORD", f"{r1['wins']}-{r1['losses']}-{r1['draws']}", f"{r2['wins']}-{r2['losses']}-{r2['draws']}")
+    compare_row(
+        "RECORD",
+        f"{r1['wins']}-{r1['losses']}-{r1['draws']}",
+        f"{r2['wins']}-{r2['losses']}-{r2['draws']}",
+    )
     compare_row("STANCE", b1.get("stance"), b2.get("stance"))
-    compare_row("HEIGHT", f"{b1.get('height_inches') or '-'} in", f"{b2.get('height_inches') or '-'} in")
-    compare_row("REACH", f"{b1.get('reach_inches') or '-'} in", f"{b2.get('reach_inches') or '-'} in")
+    compare_row(
+        "HEIGHT", f"{b1.get('height_inches') or '-'} in", f"{b2.get('height_inches') or '-'} in"
+    )
+    compare_row(
+        "REACH", f"{b1.get('reach_inches') or '-'} in", f"{b2.get('reach_inches') or '-'} in"
+    )
 
     win_pct_1 = round(r1["wins"] * 100 / r1["total_fights"], 1) if r1["total_fights"] > 0 else 0
     win_pct_2 = round(r2["wins"] * 100 / r2["total_fights"], 1) if r2["total_fights"] > 0 else 0
     compare_row("WIN %", f"{win_pct_1}%", f"{win_pct_2}%")
 
-    typer.echo(f"{'='*60}")
+    typer.echo(f"{'=' * 60}")
 
 
 def fight_impl(query: str, fmt: OutputFormat) -> None:
@@ -424,7 +445,9 @@ def fight_impl(query: str, fmt: OutputFormat) -> None:
     f1 = data["fighter1"]
     f2 = data["fighter2"]
 
-    typer.echo(f"\n{f1['fighter_name']} ({f1['result'] or 'TBD'}) vs {f2['fighter_name']} ({f2['result'] or 'TBD'})")
+    typer.echo(
+        f"\n{f1['fighter_name']} ({f1['result'] or 'TBD'}) vs {f2['fighter_name']} ({f2['result'] or 'TBD'})"
+    )
 
     if data.get("decision"):
         typer.echo(f"Result: {data['decision']}")
@@ -445,7 +468,9 @@ def fight_impl(query: str, fmt: OutputFormat) -> None:
                     tds = f"{rd.get('takedowns_landed') or 0}/{rd.get('takedowns_attempted') or 0}"
                     ctrl = rd.get("control_time_seconds") or 0
                     ctrl_str = f"{ctrl // 60}:{ctrl % 60:02d}" if ctrl else "-"
-                    typer.echo(f"  {fighter['fighter_name']}: Strikes {strikes}, TD {tds}, Ctrl {ctrl_str}")
+                    typer.echo(
+                        f"  {fighter['fighter_name']}: Strikes {strikes}, TD {tds}, Ctrl {ctrl_str}"
+                    )
 
 
 def event_impl(name: Optional[str], upcoming_only: bool, limit: int, fmt: OutputFormat) -> None:
@@ -463,7 +488,11 @@ def event_impl(name: Optional[str], upcoming_only: bool, limit: int, fmt: Output
 
         for fight in data["fights"]:
             division = format_division(fight.get("fight_division"))
-            fight_type = " [TITLE]" if fight.get("fight_type") and "title" in fight["fight_type"].lower() else ""
+            fight_type = (
+                " [TITLE]"
+                if fight.get("fight_type") and "title" in fight["fight_type"].lower()
+                else ""
+            )
 
             r1 = fight.get("fighter1_result") or "TBD"
             r2 = fight.get("fighter2_result") or "TBD"
@@ -471,7 +500,7 @@ def event_impl(name: Optional[str], upcoming_only: bool, limit: int, fmt: Output
 
             typer.echo(f"\n{division}{fight_type}")
             typer.echo(f"  {fight['fighter1_name']} ({r1})")
-            typer.echo(f"    vs")
+            typer.echo("    vs")
             typer.echo(f"  {fight['fighter2_name']} ({r2})")
             if decision:
                 rd = f" R{fight['decision_round']}" if fight.get("decision_round") else ""

--- a/panoctagon/api/cli.py
+++ b/panoctagon/api/cli.py
@@ -17,6 +17,17 @@ class OutputFormat(str, Enum):
     table = "table"
 
 
+class SortBy(str, Enum):
+    win_rate = "win_rate"
+    sig_strikes = "sig_strikes"
+    strike_accuracy = "strike_accuracy"
+    takedowns = "takedowns"
+    knockdowns = "knockdowns"
+    ko_wins = "ko_wins"
+    sub_wins = "sub_wins"
+    opp_win_rate = "opp_win_rate"
+
+
 def get_api_url() -> str:
     import os
 
@@ -260,12 +271,14 @@ def leaderboard_impl(
     limit: int,
     fmt: OutputFormat,
     interactive: bool = False,
+    sort_by: SortBy = SortBy.win_rate,
 ) -> None:
     if interactive and division is None and is_interactive():
         division = select_division()
 
     data = api_request(
-        "/rankings", {"division": division, "min_fights": min_fights, "limit": limit}
+        "/rankings",
+        {"division": division, "min_fights": min_fights, "limit": limit, "sort_by": sort_by.value},
     )
 
     if fmt == OutputFormat.json:

--- a/panoctagon/api/cli.py
+++ b/panoctagon/api/cli.py
@@ -212,7 +212,6 @@ def api_request(endpoint: str, params: Optional[dict[str, Any]] = None) -> Any:
         return response.json()
     except httpx.ConnectError:
         typer.echo(f"Error: Could not connect to API at {get_api_url()}", err=True)
-        typer.echo("Start the API server first: uv run panoctagon serve", err=True)
         raise typer.Exit(1)
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 404:

--- a/panoctagon/api/cli.py
+++ b/panoctagon/api/cli.py
@@ -403,7 +403,13 @@ def history_impl(name: str, limit: int, fmt: OutputFormat) -> None:
         decision = fight.get("decision") or "-"
         rd = f"R{fight['decision_round']}" if fight.get("decision_round") else "-"
 
-        result_style = "[green]WIN[/green]" if result == "WIN" else "[red]LOSS[/red]" if result == "LOSS" else result
+        result_style = (
+            "[green]WIN[/green]"
+            if result == "WIN"
+            else "[red]LOSS[/red]"
+            if result == "LOSS"
+            else result
+        )
         rows.append(
             {
                 "date": fight["event_date"],
@@ -477,12 +483,8 @@ def compare_impl(fighter1: str, fighter2: str, fmt: OutputFormat) -> None:
 
     r1_str = f"{r1['wins']}-{r1['losses']}-{r1['draws']}"
     r2_str = f"{r2['wins']}-{r2['losses']}-{r2['draws']}"
-    if r1["wins"] > r2["wins"]:
-        r1_str, r2_str = f"[green]{r1_str}[/green]", f"[red]{r2_str}[/red]"
-    elif r2["wins"] > r1["wins"]:
-        r1_str, r2_str = f"[red]{r1_str}[/red]", f"[green]{r2_str}[/green]"
-    table.add_row(r1_str, "RECORD", r2_str)
 
+    table.add_row(r1_str, "RECORD", r2_str)
     table.add_row(str(b1.get("stance") or "-"), "STANCE", str(b2.get("stance") or "-"))
 
     h1, h2 = compare_vals(b1.get("height_inches"), b2.get("height_inches"), suffix=" in")

--- a/panoctagon/api/cli.py
+++ b/panoctagon/api/cli.py
@@ -627,7 +627,7 @@ def roster_impl(
     max_win_rate: Optional[float],
     limit: int,
     fmt: OutputFormat,
-    sort_by: SortBy = SortBy.win_rate,
+    sort_by: SortBy,
 ) -> None:
     data = api_request(
         "/roster",

--- a/panoctagon/api/cli.py
+++ b/panoctagon/api/cli.py
@@ -396,21 +396,25 @@ def history_impl(name: str, limit: int, fmt: OutputFormat) -> None:
     fights = data["recent_fights"][:limit]
 
     typer.echo(f"\n{bio['full_name']} - Fight History")
-    typer.echo("=" * 70)
 
+    rows = []
     for fight in fights:
         result = fight.get("result") or "UPCOMING"
-        decision = fight.get("decision") or ""
-        rd = f"R{fight['decision_round']}" if fight.get("decision_round") else ""
+        decision = fight.get("decision") or "-"
+        rd = f"R{fight['decision_round']}" if fight.get("decision_round") else "-"
 
-        result_str = f"{result}"
-        if decision:
-            result_str += f" ({decision}"
-            if rd:
-                result_str += f" {rd}"
-            result_str += ")"
+        result_style = "[green]WIN[/green]" if result == "WIN" else "[red]LOSS[/red]" if result == "LOSS" else result
+        rows.append(
+            {
+                "date": fight["event_date"],
+                "opponent": f"[bold]{fight['opponent_name']}[/bold]",
+                "result": result_style,
+                "decision": decision,
+                "round": rd,
+            }
+        )
 
-        typer.echo(f"{fight['event_date']}  vs {fight['opponent_name']:<25} {result_str}")
+    typer.echo(format_table(rows))
 
 
 def compare_impl(fighter1: str, fighter2: str, fmt: OutputFormat) -> None:

--- a/panoctagon/api/cli.py
+++ b/panoctagon/api/cli.py
@@ -254,7 +254,7 @@ def upcoming_impl(fmt: OutputFormat) -> None:
         typer.echo(format_table(rows))
 
 
-def rankings_impl(
+def leaderboard_impl(
     division: Optional[str],
     min_fights: int,
     limit: int,
@@ -297,6 +297,13 @@ def rankings_impl(
                 "fighter": f"[bold]{fighter['full_name']}[/bold]",
                 "record": record,
                 "win%": f"{fighter['win_rate']:.1f}",
+                "sig\nstrikes": f"{fighter['avg_sig_strikes']:.1f}",
+                "strike\nacc%": f"{fighter['strike_accuracy']:.1f}",
+                "TDs": f"{fighter['avg_takedowns']:.1f}",
+                "KOs": fighter["ko_wins"],
+                "subs": fighter["sub_wins"],
+                "KDs": fighter["total_knockdowns"],
+                "opp\nwin%": f"{fighter['opp_win_rate']:.1f}",
             }
         )
 

--- a/panoctagon/api/models.py
+++ b/panoctagon/api/models.py
@@ -101,6 +101,11 @@ class RankedFighter(BaseModel):
     ko_wins: int
     sub_wins: int
     dec_wins: int
+    avg_sig_strikes: float
+    strike_accuracy: float
+    avg_takedowns: float
+    total_knockdowns: int
+    opp_win_rate: float
 
 
 class RosterFighter(BaseModel):

--- a/panoctagon/api/models.py
+++ b/panoctagon/api/models.py
@@ -129,11 +129,14 @@ class RosterFighter(BaseModel):
     draws: int
     win_rate: float
     total_fights: int
-    avg_strikes_landed: Optional[float]
-    avg_strikes_absorbed: Optional[float]
-    head_strike_pct: Optional[float]
-    body_strike_pct: Optional[float]
-    leg_strike_pct: Optional[float]
+    ko_wins: int
+    sub_wins: int
+    dec_wins: int
+    avg_sig_strikes: float
+    strike_accuracy: float
+    avg_takedowns: float
+    total_knockdowns: int
+    opp_win_rate: float
 
 
 class EventSummary(BaseModel):

--- a/panoctagon/api/models.py
+++ b/panoctagon/api/models.py
@@ -209,3 +209,4 @@ class FighterFightSummary(BaseModel):
     opponent_name: str
     result: Optional[str]
     decision: Optional[str]
+    decision_round: Optional[int]

--- a/panoctagon/api/models.py
+++ b/panoctagon/api/models.py
@@ -162,3 +162,34 @@ class FightDetail(BaseModel):
     referee: Optional[str]
     fighter1: FightFighterStats
     fighter2: FightFighterStats
+
+
+class EventFight(BaseModel):
+    fight_uid: str
+    fight_division: Optional[str]
+    fight_type: Optional[str]
+    fight_order: Optional[int]
+    fighter1_name: str
+    fighter1_result: Optional[str]
+    fighter2_name: str
+    fighter2_result: Optional[str]
+    decision: Optional[str]
+    decision_round: Optional[int]
+
+
+class EventDetail(BaseModel):
+    event_uid: str
+    title: str
+    event_date: str
+    event_location: str
+    fights: list[EventFight]
+
+
+class FighterFightSummary(BaseModel):
+    fight_uid: str
+    event_title: str
+    event_date: str
+    fight_division: Optional[str]
+    opponent_name: str
+    result: Optional[str]
+    decision: Optional[str]

--- a/panoctagon/api/models.py
+++ b/panoctagon/api/models.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class FighterBio(BaseModel):
+    fighter_uid: str
+    first_name: str
+    last_name: str
+    full_name: str
+    nickname: Optional[str]
+    dob: Optional[str]
+    place_of_birth: Optional[str]
+    stance: Optional[str]
+    style: Optional[str]
+    height_inches: Optional[int]
+    reach_inches: Optional[int]
+    leg_reach_inches: Optional[int]
+
+
+class FighterRecord(BaseModel):
+    wins: int
+    losses: int
+    draws: int
+    no_contests: int
+    total_fights: int
+
+
+class FightSummary(BaseModel):
+    fight_uid: str
+    event_title: str
+    event_date: str
+    fight_division: Optional[str]
+    fight_type: Optional[str]
+    opponent_name: str
+    result: Optional[str]
+    decision: Optional[str]
+    decision_round: Optional[int]
+
+
+class FighterDetail(BaseModel):
+    bio: FighterBio
+    record: FighterRecord
+    recent_fights: list[FightSummary]
+
+
+class FighterSearchResult(BaseModel):
+    fighter_uid: str
+    full_name: str
+    nickname: Optional[str]
+    stance: Optional[str]
+    division: Optional[str]
+    wins: int
+    losses: int
+    draws: int
+
+
+class UpcomingMatchup(BaseModel):
+    fight_uid: str
+    event_uid: str
+    event_title: str
+    event_date: str
+    event_location: str
+    fight_division: Optional[str]
+    fight_type: Optional[str]
+    fight_order: Optional[int]
+    fighter1_uid: str
+    fighter1_name: str
+    fighter1_record: str
+    fighter1_reach: Optional[int]
+    fighter1_height: Optional[int]
+    fighter1_stance: Optional[str]
+    fighter2_uid: str
+    fighter2_name: str
+    fighter2_record: str
+    fighter2_reach: Optional[int]
+    fighter2_height: Optional[int]
+    fighter2_stance: Optional[str]
+
+
+class UpcomingEvent(BaseModel):
+    event_uid: str
+    event_title: str
+    event_date: str
+    event_location: str
+    fights: list[UpcomingMatchup]
+
+
+class RankedFighter(BaseModel):
+    rank: int
+    fighter_uid: str
+    full_name: str
+    division: str
+    wins: int
+    losses: int
+    draws: int
+    win_rate: float
+    total_fights: int
+    ko_wins: int
+    sub_wins: int
+    dec_wins: int
+
+
+class RosterFighter(BaseModel):
+    fighter_uid: str
+    full_name: str
+    stance: Optional[str]
+    division: Optional[str]
+    wins: int
+    losses: int
+    draws: int
+    win_rate: float
+    total_fights: int
+    avg_strikes_landed: Optional[float]
+    avg_strikes_absorbed: Optional[float]
+    head_strike_pct: Optional[float]
+    body_strike_pct: Optional[float]
+    leg_strike_pct: Optional[float]
+
+
+class EventSummary(BaseModel):
+    event_uid: str
+    title: str
+    event_date: str
+    event_location: str
+    num_fights: int
+
+
+class FightRoundStats(BaseModel):
+    round_num: int
+    knockdowns: Optional[int]
+    total_strikes_landed: Optional[int]
+    total_strikes_attempted: Optional[int]
+    sig_strikes_landed: Optional[int]
+    sig_strikes_attempted: Optional[int]
+    takedowns_landed: Optional[int]
+    takedowns_attempted: Optional[int]
+    submissions_attempted: Optional[int]
+    reversals: Optional[int]
+    control_time_seconds: Optional[int]
+
+
+class FightFighterStats(BaseModel):
+    fighter_uid: str
+    fighter_name: str
+    result: Optional[str]
+    rounds: list[FightRoundStats]
+
+
+class FightDetail(BaseModel):
+    fight_uid: str
+    event_uid: str
+    event_title: str
+    event_date: str
+    fight_division: Optional[str]
+    fight_type: Optional[str]
+    decision: Optional[str]
+    decision_round: Optional[int]
+    decision_time_seconds: Optional[int]
+    referee: Optional[str]
+    fighter1: FightFighterStats
+    fighter2: FightFighterStats

--- a/panoctagon/api/models.py
+++ b/panoctagon/api/models.py
@@ -108,6 +108,17 @@ class RankedFighter(BaseModel):
     opp_win_rate: float
 
 
+class FighterStats(BaseModel):
+    avg_sig_strikes: Optional[float]
+    strike_accuracy: Optional[float]
+    avg_takedowns: Optional[float]
+    total_knockdowns: int
+    ko_wins: int
+    sub_wins: int
+    dec_wins: int
+    avg_opp_win_rate: Optional[float]
+
+
 class RosterFighter(BaseModel):
     fighter_uid: str
     full_name: str

--- a/panoctagon/api/queries.py
+++ b/panoctagon/api/queries.py
@@ -72,7 +72,9 @@ def search_fighters(
         return pl.read_database(query, connection=conn)
 
 
-def get_fighter_detail(fighter_uid: str) -> tuple[Optional[pl.DataFrame], Optional[pl.DataFrame], Optional[pl.DataFrame]]:
+def get_fighter_detail(
+    fighter_uid: str,
+) -> tuple[Optional[pl.DataFrame], Optional[pl.DataFrame], Optional[pl.DataFrame]]:
     engine = get_engine()
     with engine.connect() as conn:
         bio_query = f"""
@@ -225,7 +227,9 @@ def get_upcoming_fights() -> pl.DataFrame:
         )
 
 
-def get_rankings(division: Optional[str] = None, min_fights: int = 5, limit: int = 15) -> pl.DataFrame:
+def get_rankings(
+    division: Optional[str] = None, min_fights: int = 5, limit: int = 15
+) -> pl.DataFrame:
     engine = get_engine()
     with engine.connect() as conn:
         query = f"""

--- a/panoctagon/api/queries.py
+++ b/panoctagon/api/queries.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import polars as pl
 
+from panoctagon.api.cli import SortBy
 from panoctagon.common import get_engine
 
 
@@ -457,13 +458,12 @@ def get_rankings(
 
 
 def get_roster(
-    stance: Optional[str] = None,
     division: Optional[str] = None,
     min_fights: int = 5,
     min_win_rate: Optional[float] = None,
     max_win_rate: Optional[float] = None,
     limit: int = 100,
-    sort_by: str = "win_rate",
+    sort_by: str = SortBy.full_name,
 ) -> pl.DataFrame:
     sort_columns = {
         "win_rate": "fs.wins * 1.0 / fs.total_fights desc, fs.total_fights desc",
@@ -474,6 +474,7 @@ def get_roster(
         "ko_wins": "fs.ko_wins desc, fs.total_fights desc",
         "sub_wins": "fs.sub_wins desc, fs.total_fights desc",
         "opp_win_rate": "coalesce(fos.avg_opp_win_rate, 0) desc",
+        "full_name": "full_name",
     }
     order_by = sort_columns.get(sort_by, sort_columns["win_rate"])
 
@@ -581,8 +582,6 @@ def get_roster(
         where fs.total_fights >= {min_fights}
         """
 
-        if stance:
-            query += f" and lower(f.stance) = lower('{stance}')"
         if division:
             query += f" and lower(fdc.fight_division) = lower('{division}')"
         if min_win_rate is not None:

--- a/panoctagon/api/queries.py
+++ b/panoctagon/api/queries.py
@@ -313,9 +313,9 @@ def get_rankings(
                 sum(case when result = 'WIN' then 1 else 0 end) as wins,
                 sum(case when result = 'LOSS' then 1 else 0 end) as losses,
                 sum(case when result = 'DRAW' then 1 else 0 end) as draws,
-                sum(case when result = 'WIN' and decision in ('Knockout', 'Technical Knockout') then 1 else 0 end) as ko_wins,
-                sum(case when result = 'WIN' and decision = 'Submission' then 1 else 0 end) as sub_wins,
-                sum(case when result = 'WIN' and decision like 'Decision%' then 1 else 0 end) as dec_wins
+                sum(case when result = 'WIN' and decision = 'TKO' then 1 else 0 end) as ko_wins,
+                sum(case when result = 'WIN' and decision = 'SUB' then 1 else 0 end) as sub_wins,
+                sum(case when result = 'WIN' and decision in ('UNANIMOUS_DECISION', 'SPLIT_DECISION', 'MAJORITY_DECISION') then 1 else 0 end) as dec_wins
             from fighter_results
             group by fighter_uid
         ),

--- a/panoctagon/api/queries.py
+++ b/panoctagon/api/queries.py
@@ -1,0 +1,527 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import polars as pl
+
+from panoctagon.common import get_engine
+
+
+def search_fighters(
+    name: Optional[str] = None,
+    division: Optional[str] = None,
+    limit: int = 50,
+) -> pl.DataFrame:
+    engine = get_engine()
+    with engine.connect() as conn:
+        query = """
+        with fighter_division_counts as (
+            select
+                fighter_uid,
+                fight_division,
+                count(*) as fight_count,
+                row_number() over (partition by fighter_uid order by count(*) desc) as rn
+            from (
+                select fighter1_uid as fighter_uid, fight_division from ufc_fights
+                where fight_division is not null
+                union all
+                select fighter2_uid as fighter_uid, fight_division from ufc_fights
+                where fight_division is not null
+            )
+            group by fighter_uid, fight_division
+        ),
+        fighter_records as (
+            select
+                fighter_uid,
+                sum(case when result = 'WIN' then 1 else 0 end) as wins,
+                sum(case when result = 'LOSS' then 1 else 0 end) as losses,
+                sum(case when result = 'DRAW' then 1 else 0 end) as draws
+            from (
+                select fighter1_uid as fighter_uid, fighter1_result as result
+                from ufc_fights where fighter1_result is not null
+                union all
+                select fighter2_uid as fighter_uid, fighter2_result as result
+                from ufc_fights where fighter2_result is not null
+            )
+            group by fighter_uid
+        )
+        select
+            f.fighter_uid,
+            f.first_name || ' ' || f.last_name as full_name,
+            f.nickname,
+            f.stance,
+            fdc.fight_division as division,
+            coalesce(fr.wins, 0) as wins,
+            coalesce(fr.losses, 0) as losses,
+            coalesce(fr.draws, 0) as draws
+        from ufc_fighters f
+        left join fighter_division_counts fdc
+            on f.fighter_uid = fdc.fighter_uid and fdc.rn = 1
+        left join fighter_records fr
+            on f.fighter_uid = fr.fighter_uid
+        where 1=1
+        """
+
+        if name:
+            query += f" and lower(f.first_name || ' ' || f.last_name) like lower('%{name}%')"
+        if division:
+            query += f" and lower(fdc.fight_division) = lower('{division}')"
+
+        query += f" order by coalesce(fr.wins, 0) + coalesce(fr.losses, 0) desc limit {limit}"
+
+        return pl.read_database(query, connection=conn)
+
+
+def get_fighter_detail(fighter_uid: str) -> tuple[Optional[pl.DataFrame], Optional[pl.DataFrame], Optional[pl.DataFrame]]:
+    engine = get_engine()
+    with engine.connect() as conn:
+        bio_query = f"""
+        select
+            fighter_uid,
+            first_name,
+            last_name,
+            first_name || ' ' || last_name as full_name,
+            nickname,
+            dob,
+            place_of_birth,
+            stance,
+            style,
+            height_inches,
+            reach_inches,
+            leg_reach_inches
+        from ufc_fighters
+        where fighter_uid = '{fighter_uid}'
+        """
+        bio_df = pl.read_database(bio_query, connection=conn)
+        if bio_df.height == 0:
+            return None, None, None
+
+        record_query = f"""
+        select
+            sum(case when result = 'WIN' then 1 else 0 end) as wins,
+            sum(case when result = 'LOSS' then 1 else 0 end) as losses,
+            sum(case when result = 'DRAW' then 1 else 0 end) as draws,
+            sum(case when result = 'NO_CONTEST' then 1 else 0 end) as no_contests,
+            count(*) as total_fights
+        from (
+            select fighter1_result as result from ufc_fights where fighter1_uid = '{fighter_uid}' and fighter1_result is not null
+            union all
+            select fighter2_result as result from ufc_fights where fighter2_uid = '{fighter_uid}' and fighter2_result is not null
+        )
+        """
+        record_df = pl.read_database(record_query, connection=conn)
+
+        fights_query = f"""
+        with fighter_fights as (
+            select
+                f.fight_uid,
+                f.event_uid,
+                f.fight_division,
+                f.fight_type,
+                f.decision,
+                f.decision_round,
+                f.fighter2_uid as opponent_uid,
+                f.fighter1_result as result
+            from ufc_fights f
+            where f.fighter1_uid = '{fighter_uid}'
+            union all
+            select
+                f.fight_uid,
+                f.event_uid,
+                f.fight_division,
+                f.fight_type,
+                f.decision,
+                f.decision_round,
+                f.fighter1_uid as opponent_uid,
+                f.fighter2_result as result
+            from ufc_fights f
+            where f.fighter2_uid = '{fighter_uid}'
+        )
+        select
+            ff.fight_uid,
+            e.title as event_title,
+            e.event_date,
+            ff.fight_division,
+            ff.fight_type,
+            opp.first_name || ' ' || opp.last_name as opponent_name,
+            ff.result,
+            ff.decision,
+            ff.decision_round
+        from fighter_fights ff
+        inner join ufc_events e on ff.event_uid = e.event_uid
+        inner join ufc_fighters opp on ff.opponent_uid = opp.fighter_uid
+        order by e.event_date desc
+        limit 10
+        """
+        fights_df = pl.read_database(fights_query, connection=conn)
+
+        return bio_df, record_df, fights_df
+
+
+def get_upcoming_fights() -> pl.DataFrame:
+    engine = get_engine()
+    with engine.connect() as conn:
+        return pl.read_database(
+            """
+            with fighter_info as (
+                select
+                    fighter_uid,
+                    first_name || ' ' || last_name as fighter_name,
+                    reach_inches,
+                    height_inches,
+                    stance
+                from ufc_fighters
+            ),
+            fighter_records as (
+                select
+                    fighter_uid,
+                    sum(case when result = 'WIN' then 1 else 0 end) as wins,
+                    sum(case when result = 'LOSS' then 1 else 0 end) as losses,
+                    sum(case when result = 'DRAW' then 1 else 0 end) as draws
+                from (
+                    select fighter1_uid as fighter_uid, fighter1_result as result
+                    from ufc_fights where fighter1_result is not null
+                    union all
+                    select fighter2_uid as fighter_uid, fighter2_result as result
+                    from ufc_fights where fighter2_result is not null
+                )
+                group by fighter_uid
+            )
+            select
+                f.fight_uid,
+                f.event_uid,
+                e.title as event_title,
+                e.event_date,
+                e.event_location,
+                f.fight_division,
+                f.fight_type,
+                f.fight_order,
+                f.fighter1_uid,
+                f1.fighter_name as fighter1_name,
+                cast(coalesce(fr1.wins, 0) as varchar) || '-' ||
+                cast(coalesce(fr1.losses, 0) as varchar) || '-' ||
+                cast(coalesce(fr1.draws, 0) as varchar) as fighter1_record,
+                f1.reach_inches as fighter1_reach,
+                f1.height_inches as fighter1_height,
+                f1.stance as fighter1_stance,
+                f.fighter2_uid,
+                f2.fighter_name as fighter2_name,
+                cast(coalesce(fr2.wins, 0) as varchar) || '-' ||
+                cast(coalesce(fr2.losses, 0) as varchar) || '-' ||
+                cast(coalesce(fr2.draws, 0) as varchar) as fighter2_record,
+                f2.reach_inches as fighter2_reach,
+                f2.height_inches as fighter2_height,
+                f2.stance as fighter2_stance
+            from ufc_fights f
+            inner join ufc_events e on f.event_uid = e.event_uid
+            inner join fighter_info f1 on f.fighter1_uid = f1.fighter_uid
+            inner join fighter_info f2 on f.fighter2_uid = f2.fighter_uid
+            left join fighter_records fr1 on f.fighter1_uid = fr1.fighter_uid
+            left join fighter_records fr2 on f.fighter2_uid = fr2.fighter_uid
+            where f.fighter1_result is null
+            order by e.event_date asc, f.fight_order asc nulls last
+            """,
+            connection=conn,
+        )
+
+
+def get_rankings(division: Optional[str] = None, min_fights: int = 5, limit: int = 15) -> pl.DataFrame:
+    engine = get_engine()
+    with engine.connect() as conn:
+        query = f"""
+        with fighter_division_counts as (
+            select
+                fighter_uid,
+                fight_division,
+                count(*) as fight_count,
+                row_number() over (partition by fighter_uid order by count(*) desc) as rn
+            from (
+                select fighter1_uid as fighter_uid, fight_division from ufc_fights
+                where fight_division is not null
+                union all
+                select fighter2_uid as fighter_uid, fight_division from ufc_fights
+                where fight_division is not null
+            )
+            group by fighter_uid, fight_division
+        ),
+        fighter_results as (
+            select
+                fighter_uid,
+                result,
+                decision
+            from (
+                select fighter1_uid as fighter_uid, fighter1_result as result, decision
+                from ufc_fights where fighter1_result is not null
+                union all
+                select fighter2_uid as fighter_uid, fighter2_result as result, decision
+                from ufc_fights where fighter2_result is not null
+            )
+        ),
+        fighter_stats as (
+            select
+                fighter_uid,
+                count(*) as total_fights,
+                sum(case when result = 'WIN' then 1 else 0 end) as wins,
+                sum(case when result = 'LOSS' then 1 else 0 end) as losses,
+                sum(case when result = 'DRAW' then 1 else 0 end) as draws,
+                sum(case when result = 'WIN' and decision in ('Knockout', 'Technical Knockout') then 1 else 0 end) as ko_wins,
+                sum(case when result = 'WIN' and decision = 'Submission' then 1 else 0 end) as sub_wins,
+                sum(case when result = 'WIN' and decision like 'Decision%' then 1 else 0 end) as dec_wins
+            from fighter_results
+            group by fighter_uid
+        ),
+        ranked as (
+            select
+                f.fighter_uid,
+                f.first_name || ' ' || f.last_name as full_name,
+                fdc.fight_division as division,
+                fs.wins,
+                fs.losses,
+                fs.draws,
+                round(fs.wins * 100.0 / fs.total_fights, 1) as win_rate,
+                fs.total_fights,
+                fs.ko_wins,
+                fs.sub_wins,
+                fs.dec_wins,
+                row_number() over (
+                    partition by fdc.fight_division
+                    order by fs.wins * 1.0 / fs.total_fights desc, fs.total_fights desc
+                ) as rank
+            from ufc_fighters f
+            inner join fighter_division_counts fdc
+                on f.fighter_uid = fdc.fighter_uid and fdc.rn = 1
+            inner join fighter_stats fs
+                on f.fighter_uid = fs.fighter_uid
+            where fs.total_fights >= {min_fights}
+        )
+        select
+            rank,
+            fighter_uid,
+            full_name,
+            division,
+            wins,
+            losses,
+            draws,
+            win_rate,
+            total_fights,
+            ko_wins,
+            sub_wins,
+            dec_wins
+        from ranked
+        where 1=1
+        """
+
+        if division:
+            query += f" and lower(division) = lower('{division}')"
+
+        query += f" and rank <= {limit} order by division, rank"
+
+        return pl.read_database(query, connection=conn)
+
+
+def get_roster(
+    stance: Optional[str] = None,
+    division: Optional[str] = None,
+    min_fights: int = 5,
+    min_win_rate: Optional[float] = None,
+    max_win_rate: Optional[float] = None,
+    limit: int = 100,
+) -> pl.DataFrame:
+    engine = get_engine()
+    with engine.connect() as conn:
+        query = f"""
+        with fighter_division_counts as (
+            select
+                fighter_uid,
+                fight_division,
+                row_number() over (partition by fighter_uid order by count(*) desc) as rn
+            from (
+                select fighter1_uid as fighter_uid, fight_division from ufc_fights
+                where fight_division is not null
+                union all
+                select fighter2_uid as fighter_uid, fight_division from ufc_fights
+                where fight_division is not null
+            )
+            group by fighter_uid, fight_division
+        ),
+        fight_results_long as (
+            select fight_uid, fighter1_uid as fighter_uid, fighter1_result as fighter_result
+            from ufc_fights
+            union
+            select fight_uid, fighter2_uid as fighter_uid, fighter2_result as fighter_result
+            from ufc_fights
+        ),
+        round_stats as (
+            select
+                fs.fighter_uid,
+                fs.fight_uid,
+                fs.total_strikes_landed,
+                fs.sig_strikes_head_landed,
+                fs.sig_strikes_body_landed,
+                fs.sig_strikes_leg_landed
+            from ufc_fight_stats fs
+        ),
+        opponent_round_stats as (
+            select
+                fs.fight_uid,
+                fs.fighter_uid as opponent_uid,
+                fs.round_num,
+                fs.total_strikes_landed as opponent_strikes_landed
+            from ufc_fight_stats fs
+        ),
+        combined_rounds as (
+            select
+                rs.fighter_uid,
+                rs.fight_uid,
+                fr.fighter_result,
+                rs.total_strikes_landed,
+                ors.opponent_strikes_landed,
+                rs.sig_strikes_head_landed,
+                rs.sig_strikes_body_landed,
+                rs.sig_strikes_leg_landed
+            from round_stats rs
+            inner join ufc_fight_stats fs
+                on rs.fight_uid = fs.fight_uid and rs.fighter_uid = fs.fighter_uid
+            inner join opponent_round_stats ors
+                on rs.fight_uid = ors.fight_uid
+                and fs.round_num = ors.round_num
+                and rs.fighter_uid != ors.opponent_uid
+            inner join fight_results_long fr
+                on rs.fight_uid = fr.fight_uid
+                and rs.fighter_uid = fr.fighter_uid
+        ),
+        fighter_stats as (
+            select
+                fighter_uid,
+                count(distinct fight_uid) as total_fights,
+                count(distinct case when fighter_result = 'WIN' then fight_uid end) as wins,
+                count(distinct case when fighter_result = 'LOSS' then fight_uid end) as losses,
+                count(distinct case when fighter_result = 'DRAW' then fight_uid end) as draws,
+                percentile_cont(0.5) within group (order by total_strikes_landed) as avg_strikes_landed,
+                percentile_cont(0.5) within group (order by opponent_strikes_landed) as avg_strikes_absorbed,
+                sum(sig_strikes_head_landed) as total_head_strikes,
+                sum(sig_strikes_body_landed) as total_body_strikes,
+                sum(sig_strikes_leg_landed) as total_leg_strikes
+            from combined_rounds
+            group by fighter_uid
+        )
+        select
+            f.fighter_uid,
+            f.first_name || ' ' || f.last_name as full_name,
+            f.stance,
+            fdc.fight_division as division,
+            fs.wins,
+            fs.losses,
+            fs.draws,
+            round(fs.wins * 100.0 / fs.total_fights, 1) as win_rate,
+            fs.total_fights,
+            round(fs.avg_strikes_landed, 1) as avg_strikes_landed,
+            round(fs.avg_strikes_absorbed, 1) as avg_strikes_absorbed,
+            case when (fs.total_head_strikes + fs.total_body_strikes + fs.total_leg_strikes) > 0
+                then round(fs.total_head_strikes * 100.0 / (fs.total_head_strikes + fs.total_body_strikes + fs.total_leg_strikes), 1)
+                else null
+            end as head_strike_pct,
+            case when (fs.total_head_strikes + fs.total_body_strikes + fs.total_leg_strikes) > 0
+                then round(fs.total_body_strikes * 100.0 / (fs.total_head_strikes + fs.total_body_strikes + fs.total_leg_strikes), 1)
+                else null
+            end as body_strike_pct,
+            case when (fs.total_head_strikes + fs.total_body_strikes + fs.total_leg_strikes) > 0
+                then round(fs.total_leg_strikes * 100.0 / (fs.total_head_strikes + fs.total_body_strikes + fs.total_leg_strikes), 1)
+                else null
+            end as leg_strike_pct
+        from ufc_fighters f
+        left join fighter_division_counts fdc
+            on f.fighter_uid = fdc.fighter_uid and fdc.rn = 1
+        inner join fighter_stats fs
+            on f.fighter_uid = fs.fighter_uid
+        where fs.total_fights >= {min_fights}
+        """
+
+        if stance:
+            query += f" and lower(f.stance) = lower('{stance}')"
+        if division:
+            query += f" and lower(fdc.fight_division) = lower('{division}')"
+        if min_win_rate is not None:
+            query += f" and (fs.wins * 100.0 / fs.total_fights) >= {min_win_rate}"
+        if max_win_rate is not None:
+            query += f" and (fs.wins * 100.0 / fs.total_fights) <= {max_win_rate}"
+
+        query += f" order by fs.wins desc, fs.total_fights desc limit {limit}"
+
+        return pl.read_database(query, connection=conn)
+
+
+def get_events(upcoming_only: bool = False, limit: int = 20) -> pl.DataFrame:
+    engine = get_engine()
+    with engine.connect() as conn:
+        query = """
+        select
+            e.event_uid,
+            e.title,
+            e.event_date,
+            e.event_location,
+            count(f.fight_uid) as num_fights
+        from ufc_events e
+        left join ufc_fights f on e.event_uid = f.event_uid
+        """
+
+        if upcoming_only:
+            query += " where exists (select 1 from ufc_fights uf where uf.event_uid = e.event_uid and uf.fighter1_result is null)"
+
+        query += f" group by e.event_uid, e.title, e.event_date, e.event_location order by e.event_date desc limit {limit}"
+
+        return pl.read_database(query, connection=conn)
+
+
+def get_fight_detail(fight_uid: str) -> tuple[Optional[pl.DataFrame], Optional[pl.DataFrame]]:
+    engine = get_engine()
+    with engine.connect() as conn:
+        fight_query = f"""
+        select
+            f.fight_uid,
+            f.event_uid,
+            e.title as event_title,
+            e.event_date,
+            f.fight_division,
+            f.fight_type,
+            f.decision,
+            f.decision_round,
+            f.decision_time_seconds,
+            f.referee,
+            f.fighter1_uid,
+            f1.first_name || ' ' || f1.last_name as fighter1_name,
+            f.fighter1_result,
+            f.fighter2_uid,
+            f2.first_name || ' ' || f2.last_name as fighter2_name,
+            f.fighter2_result
+        from ufc_fights f
+        inner join ufc_events e on f.event_uid = e.event_uid
+        inner join ufc_fighters f1 on f.fighter1_uid = f1.fighter_uid
+        inner join ufc_fighters f2 on f.fighter2_uid = f2.fighter_uid
+        where f.fight_uid = '{fight_uid}'
+        """
+        fight_df = pl.read_database(fight_query, connection=conn)
+        if fight_df.height == 0:
+            return None, None
+
+        stats_query = f"""
+        select
+            fs.fighter_uid,
+            fs.round_num,
+            fs.knockdowns,
+            fs.total_strikes_landed,
+            fs.total_strikes_attempted,
+            fs.sig_strikes_landed,
+            fs.sig_strikes_attempted,
+            fs.takedowns_landed,
+            fs.takedowns_attempted,
+            fs.submissions_attempted,
+            fs.reversals,
+            fs.control_time_seconds
+        from ufc_fight_stats fs
+        where fs.fight_uid = '{fight_uid}'
+        order by fs.fighter_uid, fs.round_num
+        """
+        stats_df = pl.read_database(stats_query, connection=conn)
+
+        return fight_df, stats_df

--- a/panoctagon/api/queries.py
+++ b/panoctagon/api/queries.py
@@ -694,7 +694,8 @@ def get_fighter_fights(fighter_uid: str, limit: int = 10) -> pl.DataFrame:
                 ff.fight_division,
                 opp.first_name || ' ' || opp.last_name as opponent_name,
                 ff.result,
-                ff.decision
+                ff.decision,
+                ff.decision_round
             from fighter_fights ff
             inner join ufc_events e on ff.event_uid = e.event_uid
             inner join ufc_fighters opp on ff.opponent_uid = opp.fighter_uid

--- a/panoctagon/api/queries.py
+++ b/panoctagon/api/queries.py
@@ -75,7 +75,7 @@ def search_fighters(
 
 def get_fighter_detail(
     fighter_uid: str,
-) -> tuple[Optional[pl.DataFrame], Optional[pl.DataFrame], Optional[pl.DataFrame]]:
+) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame]:
     engine = get_engine()
     with engine.connect() as conn:
         bio_query = f"""
@@ -96,8 +96,6 @@ def get_fighter_detail(
         where fighter_uid = '{fighter_uid}'
         """
         bio_df = pl.read_database(bio_query, connection=conn)
-        if bio_df.height == 0:
-            return None, None, None
 
         record_query = f"""
         select

--- a/panoctagon/api/server.py
+++ b/panoctagon/api/server.py
@@ -193,11 +193,17 @@ def list_rankings(
 
 @app.get("/roster", response_model=list[RosterFighter])
 def list_roster(
-    stance: Optional[str] = Query(None, description="Filter by stance (Orthodox, Southpaw, Switch)"),
+    stance: Optional[str] = Query(
+        None, description="Filter by stance (Orthodox, Southpaw, Switch)"
+    ),
     division: Optional[str] = Query(None, description="Filter by weight class"),
     min_fights: int = Query(5, ge=1, description="Minimum UFC fights required"),
-    min_win_rate: Optional[float] = Query(None, ge=0, le=100, description="Minimum win rate percentage"),
-    max_win_rate: Optional[float] = Query(None, ge=0, le=100, description="Maximum win rate percentage"),
+    min_win_rate: Optional[float] = Query(
+        None, ge=0, le=100, description="Minimum win rate percentage"
+    ),
+    max_win_rate: Optional[float] = Query(
+        None, ge=0, le=100, description="Maximum win rate percentage"
+    ),
     limit: int = Query(100, ge=1, le=500, description="Maximum results to return"),
 ) -> list[RosterFighter]:
     df = get_roster(
@@ -256,7 +262,9 @@ def get_fight(fight_uid: str) -> FightDetail:
 
     fight_row = fight_df.row(0, named=True)
 
-    def build_fighter_stats(fighter_uid: str, fighter_name: str, result: Optional[str]) -> FightFighterStats:
+    def build_fighter_stats(
+        fighter_uid: str, fighter_name: str, result: Optional[str]
+    ) -> FightFighterStats:
         rounds = []
         if stats_df is not None:
             fighter_stats = stats_df.filter(stats_df["fighter_uid"] == fighter_uid)

--- a/panoctagon/api/server.py
+++ b/panoctagon/api/server.py
@@ -186,6 +186,11 @@ def list_rankings(
             ko_wins=row["ko_wins"],
             sub_wins=row["sub_wins"],
             dec_wins=row["dec_wins"],
+            avg_sig_strikes=row["avg_sig_strikes"],
+            strike_accuracy=row["strike_accuracy"],
+            avg_takedowns=row["avg_takedowns"],
+            total_knockdowns=row["total_knockdowns"],
+            opp_win_rate=row["opp_win_rate"],
         )
         for row in df.iter_rows(named=True)
     ]

--- a/panoctagon/api/server.py
+++ b/panoctagon/api/server.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Query
+
+from panoctagon.api.models import (
+    EventSummary,
+    FightDetail,
+    FightFighterStats,
+    FightRoundStats,
+    FighterBio,
+    FighterDetail,
+    FighterRecord,
+    FighterSearchResult,
+    FightSummary,
+    RankedFighter,
+    RosterFighter,
+    UpcomingEvent,
+    UpcomingMatchup,
+)
+from panoctagon.api.queries import (
+    get_events,
+    get_fight_detail,
+    get_fighter_detail,
+    get_rankings,
+    get_roster,
+    get_upcoming_fights,
+    search_fighters,
+)
+
+app = FastAPI(
+    title="Panoctagon API",
+    description="UFC fight data API",
+    version="0.1.0",
+)
+
+
+@app.get("/fighter", response_model=list[FighterSearchResult])
+def list_fighters(
+    name: Optional[str] = Query(None, description="Search fighters by name (substring match)"),
+    division: Optional[str] = Query(None, description="Filter by weight class"),
+    limit: int = Query(50, ge=1, le=200, description="Maximum results to return"),
+) -> list[FighterSearchResult]:
+    df = search_fighters(name=name, division=division, limit=limit)
+    return [
+        FighterSearchResult(
+            fighter_uid=row["fighter_uid"],
+            full_name=row["full_name"],
+            nickname=row["nickname"],
+            stance=row["stance"],
+            division=row["division"],
+            wins=row["wins"],
+            losses=row["losses"],
+            draws=row["draws"],
+        )
+        for row in df.iter_rows(named=True)
+    ]
+
+
+@app.get("/fighter/{fighter_uid}", response_model=FighterDetail)
+def get_fighter(fighter_uid: str) -> FighterDetail:
+    bio_df, record_df, fights_df = get_fighter_detail(fighter_uid)
+
+    if bio_df is None:
+        raise HTTPException(status_code=404, detail=f"Fighter {fighter_uid} not found")
+
+    bio_row = bio_df.row(0, named=True)
+    record_row = record_df.row(0, named=True)
+
+    bio = FighterBio(
+        fighter_uid=bio_row["fighter_uid"],
+        first_name=bio_row["first_name"],
+        last_name=bio_row["last_name"],
+        full_name=bio_row["full_name"],
+        nickname=bio_row["nickname"],
+        dob=bio_row["dob"],
+        place_of_birth=bio_row["place_of_birth"],
+        stance=bio_row["stance"],
+        style=bio_row["style"],
+        height_inches=bio_row["height_inches"],
+        reach_inches=bio_row["reach_inches"],
+        leg_reach_inches=bio_row["leg_reach_inches"],
+    )
+
+    record = FighterRecord(
+        wins=record_row["wins"],
+        losses=record_row["losses"],
+        draws=record_row["draws"],
+        no_contests=record_row["no_contests"],
+        total_fights=record_row["total_fights"],
+    )
+
+    recent_fights = [
+        FightSummary(
+            fight_uid=row["fight_uid"],
+            event_title=row["event_title"],
+            event_date=row["event_date"],
+            fight_division=row["fight_division"],
+            fight_type=row["fight_type"],
+            opponent_name=row["opponent_name"],
+            result=row["result"],
+            decision=row["decision"],
+            decision_round=row["decision_round"],
+        )
+        for row in fights_df.iter_rows(named=True)
+    ]
+
+    return FighterDetail(bio=bio, record=record, recent_fights=recent_fights)
+
+
+@app.get("/upcoming", response_model=list[UpcomingEvent])
+def list_upcoming() -> list[UpcomingEvent]:
+    df = get_upcoming_fights()
+
+    if df.height == 0:
+        return []
+
+    events: dict[str, UpcomingEvent] = {}
+
+    for row in df.iter_rows(named=True):
+        event_uid = row["event_uid"]
+
+        matchup = UpcomingMatchup(
+            fight_uid=row["fight_uid"],
+            event_uid=row["event_uid"],
+            event_title=row["event_title"],
+            event_date=row["event_date"],
+            event_location=row["event_location"],
+            fight_division=row["fight_division"],
+            fight_type=row["fight_type"],
+            fight_order=row["fight_order"],
+            fighter1_uid=row["fighter1_uid"],
+            fighter1_name=row["fighter1_name"],
+            fighter1_record=row["fighter1_record"],
+            fighter1_reach=row["fighter1_reach"],
+            fighter1_height=row["fighter1_height"],
+            fighter1_stance=row["fighter1_stance"],
+            fighter2_uid=row["fighter2_uid"],
+            fighter2_name=row["fighter2_name"],
+            fighter2_record=row["fighter2_record"],
+            fighter2_reach=row["fighter2_reach"],
+            fighter2_height=row["fighter2_height"],
+            fighter2_stance=row["fighter2_stance"],
+        )
+
+        if event_uid not in events:
+            events[event_uid] = UpcomingEvent(
+                event_uid=event_uid,
+                event_title=row["event_title"],
+                event_date=row["event_date"],
+                event_location=row["event_location"],
+                fights=[],
+            )
+
+        events[event_uid].fights.append(matchup)
+
+    return list(events.values())
+
+
+@app.get("/rankings", response_model=list[RankedFighter])
+def list_rankings(
+    division: Optional[str] = Query(None, description="Filter by weight class"),
+    min_fights: int = Query(5, ge=1, description="Minimum UFC fights required"),
+    limit: int = Query(15, ge=1, le=50, description="Top N fighters per division"),
+) -> list[RankedFighter]:
+    df = get_rankings(division=division, min_fights=min_fights, limit=limit)
+    return [
+        RankedFighter(
+            rank=row["rank"],
+            fighter_uid=row["fighter_uid"],
+            full_name=row["full_name"],
+            division=row["division"],
+            wins=row["wins"],
+            losses=row["losses"],
+            draws=row["draws"],
+            win_rate=row["win_rate"],
+            total_fights=row["total_fights"],
+            ko_wins=row["ko_wins"],
+            sub_wins=row["sub_wins"],
+            dec_wins=row["dec_wins"],
+        )
+        for row in df.iter_rows(named=True)
+    ]
+
+
+@app.get("/roster", response_model=list[RosterFighter])
+def list_roster(
+    stance: Optional[str] = Query(None, description="Filter by stance (Orthodox, Southpaw, Switch)"),
+    division: Optional[str] = Query(None, description="Filter by weight class"),
+    min_fights: int = Query(5, ge=1, description="Minimum UFC fights required"),
+    min_win_rate: Optional[float] = Query(None, ge=0, le=100, description="Minimum win rate percentage"),
+    max_win_rate: Optional[float] = Query(None, ge=0, le=100, description="Maximum win rate percentage"),
+    limit: int = Query(100, ge=1, le=500, description="Maximum results to return"),
+) -> list[RosterFighter]:
+    df = get_roster(
+        stance=stance,
+        division=division,
+        min_fights=min_fights,
+        min_win_rate=min_win_rate,
+        max_win_rate=max_win_rate,
+        limit=limit,
+    )
+    return [
+        RosterFighter(
+            fighter_uid=row["fighter_uid"],
+            full_name=row["full_name"],
+            stance=row["stance"],
+            division=row["division"],
+            wins=row["wins"],
+            losses=row["losses"],
+            draws=row["draws"],
+            win_rate=row["win_rate"],
+            total_fights=row["total_fights"],
+            avg_strikes_landed=row["avg_strikes_landed"],
+            avg_strikes_absorbed=row["avg_strikes_absorbed"],
+            head_strike_pct=row["head_strike_pct"],
+            body_strike_pct=row["body_strike_pct"],
+            leg_strike_pct=row["leg_strike_pct"],
+        )
+        for row in df.iter_rows(named=True)
+    ]
+
+
+@app.get("/events", response_model=list[EventSummary])
+def list_events(
+    upcoming_only: bool = Query(False, description="Only show events with upcoming fights"),
+    limit: int = Query(20, ge=1, le=100, description="Maximum events to return"),
+) -> list[EventSummary]:
+    df = get_events(upcoming_only=upcoming_only, limit=limit)
+    return [
+        EventSummary(
+            event_uid=row["event_uid"],
+            title=row["title"],
+            event_date=row["event_date"],
+            event_location=row["event_location"],
+            num_fights=row["num_fights"],
+        )
+        for row in df.iter_rows(named=True)
+    ]
+
+
+@app.get("/fight/{fight_uid}", response_model=FightDetail)
+def get_fight(fight_uid: str) -> FightDetail:
+    fight_df, stats_df = get_fight_detail(fight_uid)
+
+    if fight_df is None:
+        raise HTTPException(status_code=404, detail=f"Fight {fight_uid} not found")
+
+    fight_row = fight_df.row(0, named=True)
+
+    def build_fighter_stats(fighter_uid: str, fighter_name: str, result: Optional[str]) -> FightFighterStats:
+        rounds = []
+        if stats_df is not None:
+            fighter_stats = stats_df.filter(stats_df["fighter_uid"] == fighter_uid)
+            for row in fighter_stats.iter_rows(named=True):
+                rounds.append(
+                    FightRoundStats(
+                        round_num=row["round_num"],
+                        knockdowns=row["knockdowns"],
+                        total_strikes_landed=row["total_strikes_landed"],
+                        total_strikes_attempted=row["total_strikes_attempted"],
+                        sig_strikes_landed=row["sig_strikes_landed"],
+                        sig_strikes_attempted=row["sig_strikes_attempted"],
+                        takedowns_landed=row["takedowns_landed"],
+                        takedowns_attempted=row["takedowns_attempted"],
+                        submissions_attempted=row["submissions_attempted"],
+                        reversals=row["reversals"],
+                        control_time_seconds=row["control_time_seconds"],
+                    )
+                )
+        return FightFighterStats(
+            fighter_uid=fighter_uid,
+            fighter_name=fighter_name,
+            result=result,
+            rounds=rounds,
+        )
+
+    fighter1 = build_fighter_stats(
+        fight_row["fighter1_uid"],
+        fight_row["fighter1_name"],
+        fight_row["fighter1_result"],
+    )
+    fighter2 = build_fighter_stats(
+        fight_row["fighter2_uid"],
+        fight_row["fighter2_name"],
+        fight_row["fighter2_result"],
+    )
+
+    return FightDetail(
+        fight_uid=fight_row["fight_uid"],
+        event_uid=fight_row["event_uid"],
+        event_title=fight_row["event_title"],
+        event_date=fight_row["event_date"],
+        fight_division=fight_row["fight_division"],
+        fight_type=fight_row["fight_type"],
+        decision=fight_row["decision"],
+        decision_round=fight_row["decision_round"],
+        decision_time_seconds=fight_row["decision_time_seconds"],
+        referee=fight_row["referee"],
+        fighter1=fighter1,
+        fighter2=fighter2,
+    )
+
+
+@app.get("/health")
+def health_check() -> dict[str, str]:
+    return {"status": "ok"}

--- a/panoctagon/api/server.py
+++ b/panoctagon/api/server.py
@@ -170,8 +170,12 @@ def list_rankings(
     division: Optional[str] = Query(None, description="Filter by weight class"),
     min_fights: int = Query(5, ge=1, description="Minimum UFC fights required"),
     limit: int = Query(15, ge=1, le=50, description="Top N fighters per division"),
+    sort_by: str = Query(
+        "win_rate",
+        description="Sort by: win_rate, sig_strikes, strike_accuracy, takedowns, knockdowns, ko_wins, sub_wins, opp_win_rate",
+    ),
 ) -> list[RankedFighter]:
-    df = get_rankings(division=division, min_fights=min_fights, limit=limit)
+    df = get_rankings(division=division, min_fights=min_fights, limit=limit, sort_by=sort_by)
     return [
         RankedFighter(
             rank=row["rank"],

--- a/panoctagon/api/server.py
+++ b/panoctagon/api/server.py
@@ -420,6 +420,7 @@ def get_fighter_fights_endpoint(
             opponent_name=row["opponent_name"],
             result=row["result"],
             decision=row["decision"],
+            decision_round=row["decision_round"],
         )
         for row in df.iter_rows(named=True)
     ]

--- a/panoctagon/api/server.py
+++ b/panoctagon/api/server.py
@@ -16,6 +16,7 @@ from panoctagon.api.models import (
     FighterFightSummary,
     FighterRecord,
     FighterSearchResult,
+    FighterStats,
     FightSummary,
     RankedFighter,
     RosterFighter,
@@ -29,6 +30,7 @@ from panoctagon.api.queries import (
     get_fight_detail,
     get_fighter_detail,
     get_fighter_fights,
+    get_fighter_stats,
     get_rankings,
     get_roster,
     get_upcoming_fights,
@@ -114,6 +116,26 @@ def get_fighter(fighter_uid: str) -> FighterDetail:
     ]
 
     return FighterDetail(bio=bio, record=record, recent_fights=recent_fights)
+
+
+@app.get("/fighter/{fighter_uid}/stats", response_model=FighterStats)
+def get_fighter_stats_endpoint(fighter_uid: str) -> FighterStats:
+    df = get_fighter_stats(fighter_uid)
+
+    if df is None:
+        raise HTTPException(status_code=404, detail=f"Fighter {fighter_uid} not found")
+
+    row = df.row(0, named=True)
+    return FighterStats(
+        avg_sig_strikes=row["avg_sig_strikes"],
+        strike_accuracy=row["strike_accuracy"],
+        avg_takedowns=row["avg_takedowns"],
+        total_knockdowns=row["total_knockdowns"],
+        ko_wins=row["ko_wins"],
+        sub_wins=row["sub_wins"],
+        dec_wins=row["dec_wins"],
+        avg_opp_win_rate=row["avg_opp_win_rate"],
+    )
 
 
 @app.get("/upcoming", response_model=list[UpcomingEvent])

--- a/panoctagon/api/server.py
+++ b/panoctagon/api/server.py
@@ -9,14 +9,14 @@ from panoctagon.api.models import (
     EventFight,
     EventSummary,
     FightDetail,
-    FightFighterStats,
-    FightRoundStats,
     FighterBio,
     FighterDetail,
     FighterFightSummary,
     FighterRecord,
     FighterSearchResult,
     FighterStats,
+    FightFighterStats,
+    FightRoundStats,
     FightSummary,
     RankedFighter,
     RosterFighter,
@@ -236,6 +236,10 @@ def list_roster(
         None, ge=0, le=100, description="Maximum win rate percentage"
     ),
     limit: int = Query(100, ge=1, le=500, description="Maximum results to return"),
+    sort_by: str = Query(
+        "win_rate",
+        description="Sort by: win_rate, sig_strikes, strike_accuracy, takedowns, knockdowns, ko_wins, sub_wins, opp_win_rate",
+    ),
 ) -> list[RosterFighter]:
     df = get_roster(
         stance=stance,
@@ -244,6 +248,7 @@ def list_roster(
         min_win_rate=min_win_rate,
         max_win_rate=max_win_rate,
         limit=limit,
+        sort_by=sort_by,
     )
     return [
         RosterFighter(
@@ -256,11 +261,14 @@ def list_roster(
             draws=row["draws"],
             win_rate=row["win_rate"],
             total_fights=row["total_fights"],
-            avg_strikes_landed=row["avg_strikes_landed"],
-            avg_strikes_absorbed=row["avg_strikes_absorbed"],
-            head_strike_pct=row["head_strike_pct"],
-            body_strike_pct=row["body_strike_pct"],
-            leg_strike_pct=row["leg_strike_pct"],
+            ko_wins=row["ko_wins"],
+            sub_wins=row["sub_wins"],
+            dec_wins=row["dec_wins"],
+            avg_sig_strikes=row["avg_sig_strikes"],
+            strike_accuracy=row["strike_accuracy"],
+            avg_takedowns=row["avg_takedowns"],
+            total_knockdowns=row["total_knockdowns"],
+            opp_win_rate=row["opp_win_rate"],
         )
         for row in df.iter_rows(named=True)
     ]

--- a/panoctagon/api/server.py
+++ b/panoctagon/api/server.py
@@ -224,9 +224,6 @@ def list_rankings(
 
 @app.get("/roster", response_model=list[RosterFighter])
 def list_roster(
-    stance: Optional[str] = Query(
-        None, description="Filter by stance (Orthodox, Southpaw, Switch)"
-    ),
     division: Optional[str] = Query(None, description="Filter by weight class"),
     min_fights: int = Query(5, ge=1, description="Minimum UFC fights required"),
     min_win_rate: Optional[float] = Query(
@@ -242,7 +239,6 @@ def list_roster(
     ),
 ) -> list[RosterFighter]:
     df = get_roster(
-        stance=stance,
         division=division,
         min_fights=min_fights,
         min_win_rate=min_win_rate,

--- a/panoctagon/app.py
+++ b/panoctagon/app.py
@@ -53,7 +53,9 @@ def rankings(
     division: Optional[str] = typer.Option(None, "--division", "-d", help="Filter by weight class"),
     min_fights: int = typer.Option(5, "--min-fights", "-m", help="Minimum UFC fights"),
     limit: int = typer.Option(15, "--limit", "-l", help="Top N per division"),
-    interactive: bool = typer.Option(False, "--interactive", "-i", help="Interactively select division"),
+    interactive: bool = typer.Option(
+        False, "--interactive", "-i", help="Interactively select division"
+    ),
     fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
 ) -> None:
     """Show fighter rankings by win rate within each division."""

--- a/panoctagon/app.py
+++ b/panoctagon/app.py
@@ -84,16 +84,16 @@ def event(
 
 @app.command()
 def roster(
-    stance: Optional[str] = typer.Option(None, "--stance", "-s", help="Filter by stance"),
     division: Optional[str] = typer.Option(None, "--division", "-d", help="Filter by weight class"),
     min_fights: int = typer.Option(5, "--min-fights", "-m", help="Minimum UFC fights"),
     min_win_rate: Optional[float] = typer.Option(None, "--min-win-rate", help="Minimum win rate %"),
     max_win_rate: Optional[float] = typer.Option(None, "--max-win-rate", help="Maximum win rate %"),
     limit: int = typer.Option(50, "--limit", "-l", help="Maximum results"),
     fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+    sort_by: SortBy = typer.Option(SortBy.full_name, "--sort", "-s", help="Metric to sort by"),
 ) -> None:
     """Search the UFC roster with filters."""
-    roster_impl(stance, division, min_fights, min_win_rate, max_win_rate, limit, fmt)
+    roster_impl(division, min_fights, min_win_rate, max_win_rate, limit, fmt, sort_by)
 
 
 if __name__ == "__main__":

--- a/panoctagon/app.py
+++ b/panoctagon/app.py
@@ -3,6 +3,7 @@ from typing import Optional
 import typer
 
 from panoctagon.api.cli import (
+    Division,
     OutputFormat,
     SortBy,
     compare_impl,
@@ -27,7 +28,9 @@ def upcoming(
 
 @app.command()
 def leaderboard(
-    division: Optional[str] = typer.Option(None, "--division", "-d", help="Filter by weight class"),
+    division: Division | None = typer.Option(
+        None, "--division", "-d", help="Filter by weight class"
+    ),
     min_fights: int = typer.Option(5, "--min-fights", "-m", help="Minimum UFC fights"),
     limit: int = typer.Option(15, "--limit", "-l", help="Top N per division"),
     sort_by: SortBy = typer.Option(SortBy.win_rate, "--sort", "-s", help="Metric to sort by"),
@@ -84,7 +87,9 @@ def event(
 
 @app.command()
 def roster(
-    division: Optional[str] = typer.Option(None, "--division", "-d", help="Filter by weight class"),
+    division: Division | None = typer.Option(
+        None, "--division", "-d", help="Filter by weight class"
+    ),
     min_fights: int = typer.Option(5, "--min-fights", "-m", help="Minimum UFC fights"),
     min_win_rate: Optional[float] = typer.Option(None, "--min-win-rate", help="Minimum win rate %"),
     max_win_rate: Optional[float] = typer.Option(None, "--max-win-rate", help="Maximum win rate %"),

--- a/panoctagon/app.py
+++ b/panoctagon/app.py
@@ -11,11 +11,8 @@ from panoctagon.api.cli import (
     event_impl,
     fight_impl,
     fighter_impl,
-    history_impl,
     leaderboard_impl,
-    record_impl,
     roster_impl,
-    search_impl,
     upcoming_impl,
 )
 
@@ -65,42 +62,15 @@ def leaderboard(
 
 
 @app.command()
-def search(
-    name: str = typer.Argument(..., help="Fighter name to search"),
-    division: Optional[str] = typer.Option(None, "--division", "-d", help="Filter by weight class"),
-    limit: int = typer.Option(20, "--limit", "-l", help="Maximum results"),
-    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
-) -> None:
-    """Search for fighters by name."""
-    search_impl(name, division, limit, fmt)
-
-
-@app.command()
 def fighter(
     name: str = typer.Argument(..., help="Fighter name"),
+    history: int = typer.Option(
+        None, "--history", "-H", help="Show extended fight history (specify number of fights)"
+    ),
     fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
 ) -> None:
-    """Get detailed information about a fighter."""
-    fighter_impl(name, fmt)
-
-
-@app.command()
-def record(
-    name: str = typer.Argument(..., help="Fighter name"),
-    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
-) -> None:
-    """Get a fighter's win-loss-draw record."""
-    record_impl(name, fmt)
-
-
-@app.command()
-def history(
-    name: str = typer.Argument(..., help="Fighter name"),
-    limit: int = typer.Option(10, "--limit", "-l", help="Number of fights to show"),
-    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
-) -> None:
-    """Show a fighter's fight history."""
-    history_impl(name, limit, fmt)
+    """Get detailed information about a fighter. Use --history to see extended fight history."""
+    fighter_impl(name, fmt, history)
 
 
 @app.command()

--- a/panoctagon/app.py
+++ b/panoctagon/app.py
@@ -1,13 +1,26 @@
+from typing import Optional
+
 import typer
 
-import panoctagon.api.cli as data
 import panoctagon.one.one as one
 import panoctagon.ufc.app as ufc
+from panoctagon.api.cli import (
+    OutputFormat,
+    compare_impl,
+    event_impl,
+    fight_impl,
+    fighter_impl,
+    history_impl,
+    rankings_impl,
+    record_impl,
+    roster_impl,
+    search_impl,
+    upcoming_impl,
+)
 
 app = typer.Typer(pretty_exceptions_enable=False)
 app.add_typer(ufc.app, name="ufc")
 app.add_typer(one.app, name="one")
-app.add_typer(data.app, name="data")
 
 
 @app.command()
@@ -25,6 +38,107 @@ def serve(
         port=port,
         reload=reload,
     )
+
+
+@app.command()
+def upcoming(
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """Show upcoming UFC events and matchups."""
+    upcoming_impl(fmt)
+
+
+@app.command()
+def rankings(
+    division: Optional[str] = typer.Option(None, "--division", "-d", help="Filter by weight class"),
+    min_fights: int = typer.Option(5, "--min-fights", "-m", help="Minimum UFC fights"),
+    limit: int = typer.Option(15, "--limit", "-l", help="Top N per division"),
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """Show fighter rankings by win rate within each division."""
+    rankings_impl(division, min_fights, limit, fmt)
+
+
+@app.command()
+def search(
+    name: str = typer.Argument(..., help="Fighter name to search"),
+    division: Optional[str] = typer.Option(None, "--division", "-d", help="Filter by weight class"),
+    limit: int = typer.Option(20, "--limit", "-l", help="Maximum results"),
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """Search for fighters by name."""
+    search_impl(name, division, limit, fmt)
+
+
+@app.command()
+def fighter(
+    name: str = typer.Argument(..., help="Fighter name"),
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """Get detailed information about a fighter."""
+    fighter_impl(name, fmt)
+
+
+@app.command()
+def record(
+    name: str = typer.Argument(..., help="Fighter name"),
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """Get a fighter's win-loss-draw record."""
+    record_impl(name, fmt)
+
+
+@app.command()
+def history(
+    name: str = typer.Argument(..., help="Fighter name"),
+    limit: int = typer.Option(10, "--limit", "-l", help="Number of fights to show"),
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """Show a fighter's fight history."""
+    history_impl(name, limit, fmt)
+
+
+@app.command()
+def compare(
+    fighter1: str = typer.Argument(..., help="First fighter name"),
+    fighter2: str = typer.Argument(..., help="Second fighter name"),
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """Compare two fighters side-by-side."""
+    compare_impl(fighter1, fighter2, fmt)
+
+
+@app.command()
+def fight(
+    fight_uid: str = typer.Argument(..., help="Fight UID"),
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """Get detailed statistics for a specific fight."""
+    fight_impl(fight_uid, fmt)
+
+
+@app.command()
+def event(
+    upcoming_only: bool = typer.Option(False, "--upcoming", "-u", help="Only show upcoming events"),
+    limit: int = typer.Option(20, "--limit", "-l", help="Maximum events"),
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """List UFC events."""
+    event_impl(upcoming_only, limit, fmt)
+
+
+@app.command()
+def roster(
+    stance: Optional[str] = typer.Option(None, "--stance", "-s", help="Filter by stance"),
+    division: Optional[str] = typer.Option(None, "--division", "-d", help="Filter by weight class"),
+    min_fights: int = typer.Option(5, "--min-fights", "-m", help="Minimum UFC fights"),
+    min_win_rate: Optional[float] = typer.Option(None, "--min-win-rate", help="Minimum win rate %"),
+    max_win_rate: Optional[float] = typer.Option(None, "--max-win-rate", help="Maximum win rate %"),
+    limit: int = typer.Option(50, "--limit", "-l", help="Maximum results"),
+    fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
+) -> None:
+    """Search the UFC roster with filters."""
+    roster_impl(stance, division, min_fights, min_win_rate, max_win_rate, limit, fmt)
 
 
 if __name__ == "__main__":

--- a/panoctagon/app.py
+++ b/panoctagon/app.py
@@ -53,10 +53,11 @@ def rankings(
     division: Optional[str] = typer.Option(None, "--division", "-d", help="Filter by weight class"),
     min_fights: int = typer.Option(5, "--min-fights", "-m", help="Minimum UFC fights"),
     limit: int = typer.Option(15, "--limit", "-l", help="Top N per division"),
+    interactive: bool = typer.Option(False, "--interactive", "-i", help="Interactively select division"),
     fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
 ) -> None:
     """Show fighter rankings by win rate within each division."""
-    rankings_impl(division, min_fights, limit, fmt)
+    rankings_impl(division, min_fights, limit, fmt, interactive)
 
 
 @app.command()
@@ -110,21 +111,22 @@ def compare(
 
 @app.command()
 def fight(
-    fight_uid: str = typer.Argument(..., help="Fight UID"),
+    name: str = typer.Argument(..., help="Fighter name to look up fights for"),
     fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
 ) -> None:
-    """Get detailed statistics for a specific fight."""
-    fight_impl(fight_uid, fmt)
+    """Get detailed statistics for a fight. Search by fighter name, then select a fight."""
+    fight_impl(name, fmt)
 
 
 @app.command()
 def event(
+    name: Optional[str] = typer.Argument(None, help="Event name to search for"),
     upcoming_only: bool = typer.Option(False, "--upcoming", "-u", help="Only show upcoming events"),
     limit: int = typer.Option(20, "--limit", "-l", help="Maximum events"),
     fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
 ) -> None:
-    """List UFC events."""
-    event_impl(upcoming_only, limit, fmt)
+    """List UFC events, or view a specific event's card by name."""
+    event_impl(name, upcoming_only, limit, fmt)
 
 
 @app.command()

--- a/panoctagon/app.py
+++ b/panoctagon/app.py
@@ -11,7 +11,7 @@ from panoctagon.api.cli import (
     fight_impl,
     fighter_impl,
     history_impl,
-    rankings_impl,
+    leaderboard_impl,
     record_impl,
     roster_impl,
     search_impl,
@@ -49,7 +49,7 @@ def upcoming(
 
 
 @app.command()
-def rankings(
+def leaderboard(
     division: Optional[str] = typer.Option(None, "--division", "-d", help="Filter by weight class"),
     min_fights: int = typer.Option(5, "--min-fights", "-m", help="Minimum UFC fights"),
     limit: int = typer.Option(15, "--limit", "-l", help="Top N per division"),
@@ -58,8 +58,8 @@ def rankings(
     ),
     fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
 ) -> None:
-    """Show fighter rankings by win rate within each division."""
-    rankings_impl(division, min_fights, limit, fmt, interactive)
+    """Show fighters ranked by win rate within each division."""
+    leaderboard_impl(division, min_fights, limit, fmt, interactive)
 
 
 @app.command()

--- a/panoctagon/app.py
+++ b/panoctagon/app.py
@@ -6,6 +6,7 @@ import panoctagon.one.one as one
 import panoctagon.ufc.app as ufc
 from panoctagon.api.cli import (
     OutputFormat,
+    SortBy,
     compare_impl,
     event_impl,
     fight_impl,
@@ -53,13 +54,14 @@ def leaderboard(
     division: Optional[str] = typer.Option(None, "--division", "-d", help="Filter by weight class"),
     min_fights: int = typer.Option(5, "--min-fights", "-m", help="Minimum UFC fights"),
     limit: int = typer.Option(15, "--limit", "-l", help="Top N per division"),
+    sort_by: SortBy = typer.Option(SortBy.win_rate, "--sort", "-s", help="Metric to sort by"),
     interactive: bool = typer.Option(
         False, "--interactive", "-i", help="Interactively select division"
     ),
     fmt: OutputFormat = typer.Option(OutputFormat.table, "--format", "-f", help="Output format"),
 ) -> None:
     """Show fighters ranked by win rate within each division."""
-    leaderboard_impl(division, min_fights, limit, fmt, interactive)
+    leaderboard_impl(division, min_fights, limit, fmt, interactive, sort_by)
 
 
 @app.command()

--- a/panoctagon/app.py
+++ b/panoctagon/app.py
@@ -2,8 +2,6 @@ from typing import Optional
 
 import typer
 
-import panoctagon.one.one as one
-import panoctagon.ufc.app as ufc
 from panoctagon.api.cli import (
     OutputFormat,
     SortBy,
@@ -17,25 +15,6 @@ from panoctagon.api.cli import (
 )
 
 app = typer.Typer(pretty_exceptions_enable=False)
-app.add_typer(ufc.app, name="ufc")
-app.add_typer(one.app, name="one")
-
-
-@app.command()
-def serve(
-    host: str = typer.Option("127.0.0.1", "--host", "-h", help="Host to bind to"),
-    port: int = typer.Option(8000, "--port", "-p", help="Port to bind to"),
-    reload: bool = typer.Option(False, "--reload", "-r", help="Enable auto-reload"),
-) -> None:
-    """Start the Panoctagon API server."""
-    import uvicorn
-
-    uvicorn.run(
-        "panoctagon.api.server:app",
-        host=host,
-        port=port,
-        reload=reload,
-    )
 
 
 @app.command()

--- a/panoctagon/app.py
+++ b/panoctagon/app.py
@@ -1,11 +1,31 @@
 import typer
 
+import panoctagon.api.cli as data
 import panoctagon.one.one as one
 import panoctagon.ufc.app as ufc
 
 app = typer.Typer(pretty_exceptions_enable=False)
 app.add_typer(ufc.app, name="ufc")
 app.add_typer(one.app, name="one")
+app.add_typer(data.app, name="data")
+
+
+@app.command()
+def serve(
+    host: str = typer.Option("127.0.0.1", "--host", "-h", help="Host to bind to"),
+    port: int = typer.Option(8000, "--port", "-p", help="Port to bind to"),
+    reload: bool = typer.Option(False, "--reload", "-r", help="Enable auto-reload"),
+) -> None:
+    """Start the Panoctagon API server."""
+    import uvicorn
+
+    uvicorn.run(
+        "panoctagon.api.server:app",
+        host=host,
+        port=port,
+        reload=reload,
+    )
+
 
 if __name__ == "__main__":
     app()

--- a/panoctagon/dashboard/pages/fighter.py
+++ b/panoctagon/dashboard/pages/fighter.py
@@ -15,6 +15,7 @@ from panoctagon.dashboard.common import (
     get_headshot_base64,
     get_main_data,
 )
+from panoctagon.enums import format_decision, format_result
 
 
 def get_fighter_uid_map(df: pl.DataFrame) -> dict[str, str]:
@@ -276,33 +277,6 @@ def update_career_timeline(fighter: str):
     )
 
     return apply_figure_styling(fig)
-
-
-def format_decision(decision: str) -> str:
-    decision_map = {
-        "UNANIMOUS_DECISION": "Unanimous Decision",
-        "SPLIT_DECISION": "Split Decision",
-        "MAJORITY_DECISION": "Majority Decision",
-        "TKO": "TKO",
-        "KO": "KO",
-        "SUB": "Submission",
-        "DQ": "DQ",
-        "DOC": "Doctor Stoppage",
-        "OVERTURNED": "Overturned",
-        "COULD_NOT_CONTINUE": "Could Not Continue",
-        "OTHER": "Other",
-    }
-    return decision_map.get(decision, decision)
-
-
-def format_result(result: str) -> str:
-    result_map = {
-        "WIN": "W",
-        "LOSS": "L",
-        "DRAW": "D",
-        "NO_CONTEST": "NC",
-    }
-    return result_map.get(result, result)
 
 
 @callback(

--- a/panoctagon/enums.py
+++ b/panoctagon/enums.py
@@ -82,3 +82,43 @@ class ONEDivisionNames(str, Enum):
     MIDDLEWEIGHT = "Middleweight"
     LIGHT_HEAVYWEIGHT = "Light Heavyweight"
     HEAVYWEIGHT = "Heavyweight"
+
+
+def format_decision(decision: str | None) -> str:
+    if decision is None:
+        return "Unknown"
+
+    decision_map = {
+        "UNANIMOUS_DECISION": "Unanimous Decision",
+        "SPLIT_DECISION": "Split Decision",
+        "MAJORITY_DECISION": "Majority Decision",
+        "TKO": "TKO",
+        "KO": "KO",
+        "SUB": "Submission",
+        "DQ": "DQ",
+        "DOC": "Doctor Stoppage",
+        "OVERTURNED": "Overturned",
+        "COULD_NOT_CONTINUE": "Could Not Continue",
+        "OTHER": "Other",
+    }
+    return decision_map.get(decision, decision)
+
+
+def format_result(result: str | None) -> str:
+    if result is None:
+        return "Unknown"
+
+    result_map = {
+        "WIN": "W",
+        "LOSS": "L",
+        "DRAW": "D",
+        "NO_CONTEST": "NC",
+    }
+    return result_map.get(result, result)
+
+
+def format_division(div: str | None) -> str:
+    if div is None:
+        return "Unknown"
+
+    return div.replace("_", " ").title()

--- a/panoctagon/ufc/scrape/bios.py
+++ b/panoctagon/ufc/scrape/bios.py
@@ -258,8 +258,6 @@ def scrape_fighter_bios_parallel(
     base_dir: Path,
     max_workers: int = 3,
 ) -> list[FighterBioScrapingResult]:
-
-
     total_fighters = len(fighters)
     results = []
     completed_count = 0

--- a/panoctagon/ufc/scrape/fighters.py
+++ b/panoctagon/ufc/scrape/fighters.py
@@ -41,7 +41,9 @@ def get_all_fighter_uids() -> list[str]:
     return sorted(set(f1_uids + f2_uids))
 
 
-def scrape_fighter(fighter: FighterToScrape, session: Optional[requests.Session] = None) -> FighterScrapingResult:
+def scrape_fighter(
+    fighter: FighterToScrape, session: Optional[requests.Session] = None
+) -> FighterScrapingResult:
     title = f"[{fighter.i + 1:04d}/{fighter.n_fighters:04d}] {fighter.uid}"
     print(create_header(80, title, False, "."))
     base_url = "http://ufcstats.com/fighter-details"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ ignore = [ "dbt_packages" ]
 
 [project.scripts]
 panoctagon = "panoctagon.app:app"
+admin = "panoctagon.admin:app"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "uvicorn==0.34.2",
     "httpx==0.28.1",
     "questionary==2.1.0",
+    "rich==14.0.0",
 ]
 
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ venv = ".venv"
 typeCheckingMode = "standard"
 ignore = [ "dbt_packages" ]
 
+[project.scripts]
+panoctagon = "panoctagon.app:app"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "fastapi==0.115.12",
     "uvicorn==0.34.2",
     "httpx==0.28.1",
-    "questionary==2.1.0",
+    "questionary>=2.1.1",
     "rich==14.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
     "dbt-duckdb==1.9.0",
     "dagster-dg-cli>=1.12.12",
     "networkx==3.4.2",
+    "fastapi==0.115.12",
+    "uvicorn==0.34.2",
+    "httpx==0.28.1",
 ]
 
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "fastapi==0.115.12",
     "uvicorn==0.34.2",
     "httpx==0.28.1",
+    "questionary==2.1.0",
 ]
 
 [tool.pyright]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 resolution-markers = [
     "sys_platform == 'win32'",
@@ -749,6 +749,20 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.115.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/55/ae499352d82338331ca1e28c7f4a63bfd09479b16395dce38cf50a39e2c2/fastapi-0.115.12.tar.gz", hash = "sha256:1e2c2a2646905f9e83d32f04a3f86aff4a286669c6c950ca95b5fd68c2602681", size = 295236, upload-time = "2025-03-23T22:55:43.822Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/b3/b51f09c2ba432a576fe63758bddc81f78f0c6309d9e5c10d194313bf021e/fastapi-0.115.12-py3-none-any.whl", hash = "sha256:e94613d6c05e27be7ffebdd6ea5f388112e5e430c8f7d6494a9d1d88d43e814d", size = 95164, upload-time = "2025-03-23T22:55:42.101Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.20.3"
 source = { registry = "https://pypi.org/simple" }
@@ -888,7 +902,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/c8/9d76a66421d1ae24340dfae7e79c313957f6e3195c144d2c73333b5bfe34/greenlet-3.3.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7e806ca53acf6d15a888405880766ec84721aa4181261cd11a457dfe9a7a4975", size = 276443, upload-time = "2026-01-23T15:30:10.066Z" },
     { url = "https://files.pythonhosted.org/packages/81/99/401ff34bb3c032d1f10477d199724f5e5f6fbfb59816ad1455c79c1eb8e7/greenlet-3.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d842c94b9155f1c9b3058036c24ffb8ff78b428414a19792b2380be9cecf4f36", size = 597359, upload-time = "2026-01-23T16:00:57.394Z" },
     { url = "https://files.pythonhosted.org/packages/2b/bc/4dcc0871ed557792d304f50be0f7487a14e017952ec689effe2180a6ff35/greenlet-3.3.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:20fedaadd422fa02695f82093f9a98bad3dab5fcda793c658b945fcde2ab27ba", size = 607805, upload-time = "2026-01-23T16:05:28.068Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/cd/7a7ca57588dac3389e97f7c9521cb6641fd8b6602faf1eaa4188384757df/greenlet-3.3.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c620051669fd04ac6b60ebc70478210119c56e2d5d5df848baec4312e260e4ca", size = 622363, upload-time = "2026-01-23T16:15:54.754Z" },
     { url = "https://files.pythonhosted.org/packages/cf/05/821587cf19e2ce1f2b24945d890b164401e5085f9d09cbd969b0c193cd20/greenlet-3.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14194f5f4305800ff329cbf02c5fcc88f01886cadd29941b807668a45f0d2336", size = 609947, upload-time = "2026-01-23T15:32:51.004Z" },
     { url = "https://files.pythonhosted.org/packages/a4/52/ee8c46ed9f8babaa93a19e577f26e3d28a519feac6350ed6f25f1afee7e9/greenlet-3.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7b2fe4150a0cf59f847a67db8c155ac36aed89080a6a639e9f16df5d6c6096f1", size = 1567487, upload-time = "2026-01-23T16:04:22.125Z" },
     { url = "https://files.pythonhosted.org/packages/8f/7c/456a74f07029597626f3a6db71b273a3632aecb9afafeeca452cfa633197/greenlet-3.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:49f4ad195d45f4a66a0eb9c1ba4832bb380570d361912fa3554746830d332149", size = 1636087, upload-time = "2026-01-23T15:33:47.486Z" },
@@ -952,6 +965,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -964,6 +990,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
     { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
     { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -1387,7 +1428,9 @@ dependencies = [
     { name = "dbt-duckdb" },
     { name = "duckdb" },
     { name = "duckdb-engine" },
+    { name = "fastapi" },
     { name = "gunicorn" },
+    { name = "httpx" },
     { name = "lxml" },
     { name = "networkx" },
     { name = "pandas" },
@@ -1397,12 +1440,14 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "questionary" },
     { name = "requests" },
     { name = "ruff-lsp" },
     { name = "shandy-sqlfmt", extra = ["jinjafmt"] },
     { name = "sqlmodel" },
     { name = "statsmodels" },
     { name = "typer" },
+    { name = "uvicorn" },
 ]
 
 [package.metadata]
@@ -1419,7 +1464,9 @@ requires-dist = [
     { name = "dbt-duckdb", specifier = "==1.9.0" },
     { name = "duckdb", specifier = "==1.1.0" },
     { name = "duckdb-engine", specifier = "==0.13.2" },
+    { name = "fastapi", specifier = "==0.115.12" },
     { name = "gunicorn", specifier = "==24.1.1" },
+    { name = "httpx", specifier = "==0.28.1" },
     { name = "lxml", specifier = "==6.0.2" },
     { name = "networkx", specifier = "==3.4.2" },
     { name = "pandas", specifier = "==3.0.0" },
@@ -1429,12 +1476,14 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pyright", specifier = "==1.1.408" },
     { name = "pytest", specifier = "==9.0.2" },
+    { name = "questionary", specifier = "==2.1.0" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "ruff-lsp", specifier = "==0.0.62" },
     { name = "shandy-sqlfmt", extras = ["jinjafmt"], specifier = "==0.29.0" },
     { name = "sqlmodel", specifier = "==0.0.31" },
     { name = "statsmodels", specifier = "==0.14.6" },
     { name = "typer", specifier = "<=0.17" },
+    { name = "uvicorn", specifier = "==0.34.2" },
 ]
 
 [[package]]
@@ -1834,14 +1883,14 @@ wheels = [
 
 [[package]]
 name = "questionary"
-version = "2.1.1"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "prompt-toolkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/b8/d16eb579277f3de9e56e5ad25280fab52fc5774117fb70362e8c2e016559/questionary-2.1.0.tar.gz", hash = "sha256:6302cdd645b19667d8f6e6634774e9538bfcd1aad9be287e743d96cacaf95587", size = 26775, upload-time = "2024-12-29T11:49:17.802Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3f/11dd4cd4f39e05128bfd20138faea57bec56f9ffba6185d276e3107ba5b2/questionary-2.1.0-py3-none-any.whl", hash = "sha256:44174d237b68bc828e4878c763a9ad6790ee61990e0ae72927694ead57bab8ec", size = 36747, upload-time = "2024-12-29T11:49:16.734Z" },
 ]
 
 [[package]]
@@ -2147,15 +2196,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "0.46.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846, upload-time = "2025-04-13T13:56:17.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037, upload-time = "2025-04-13T13:56:16.21Z" },
 ]
 
 [[package]]
@@ -2341,15 +2389,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.40.0"
+version = "0.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/ae/9bbb19b9e1c450cf9ecaef06463e40234d98d95bf572fab11b4f19ae5ded/uvicorn-0.34.2.tar.gz", hash = "sha256:0e929828f6186353a80b58ea719861d2629d766293b6d19baf086ba31d4f3328", size = 76815, upload-time = "2025-04-19T06:02:50.101Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/4b/4cef6ce21a2aaca9d852a6e84ef4f135d99fcd74fa75105e2fc0c8308acd/uvicorn-0.34.2-py3-none-any.whl", hash = "sha256:deb49af569084536d269fe0a6d67e3754f104cf03aba7c11c40f01aadf33c403", size = 62483, upload-time = "2025-04-19T06:02:48.42Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1477,7 +1477,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pyright", specifier = "==1.1.408" },
     { name = "pytest", specifier = "==9.0.2" },
-    { name = "questionary", specifier = "==2.1.0" },
+    { name = "questionary", specifier = ">=2.1.1" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "rich", specifier = "==14.0.0" },
     { name = "ruff-lsp", specifier = "==0.0.62" },
@@ -1885,14 +1885,14 @@ wheels = [
 
 [[package]]
 name = "questionary"
-version = "2.1.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "prompt-toolkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/b8/d16eb579277f3de9e56e5ad25280fab52fc5774117fb70362e8c2e016559/questionary-2.1.0.tar.gz", hash = "sha256:6302cdd645b19667d8f6e6634774e9538bfcd1aad9be287e743d96cacaf95587", size = 26775, upload-time = "2024-12-29T11:49:17.802Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/3f/11dd4cd4f39e05128bfd20138faea57bec56f9ffba6185d276e3107ba5b2/questionary-2.1.0-py3-none-any.whl", hash = "sha256:44174d237b68bc828e4878c763a9ad6790ee61990e0ae72927694ead57bab8ec", size = 36747, upload-time = "2024-12-29T11:49:16.734Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1442,6 +1442,7 @@ dependencies = [
     { name = "pytest" },
     { name = "questionary" },
     { name = "requests" },
+    { name = "rich" },
     { name = "ruff-lsp" },
     { name = "shandy-sqlfmt", extra = ["jinjafmt"] },
     { name = "sqlmodel" },
@@ -1478,6 +1479,7 @@ requires-dist = [
     { name = "pytest", specifier = "==9.0.2" },
     { name = "questionary", specifier = "==2.1.0" },
     { name = "requests", specifier = "==2.32.5" },
+    { name = "rich", specifier = "==14.0.0" },
     { name = "ruff-lsp", specifier = "==0.0.62" },
     { name = "shandy-sqlfmt", extras = ["jinjafmt"], specifier = "==0.29.0" },
     { name = "sqlmodel", specifier = "==0.0.31" },
@@ -1945,15 +1947,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "14.3.1"
+version = "14.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/84/4831f881aa6ff3c976f6d6809b58cdfa350593ffc0dc3c58f5f6586780fb/rich-14.3.1.tar.gz", hash = "sha256:b8c5f568a3a749f9290ec6bddedf835cec33696bfc1e48bcfecb276c7386e4b8", size = 230125, upload-time = "2026-01-24T21:40:44.847Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/2a/a1810c8627b9ec8c57ec5ec325d306701ae7be50235e8fd81266e002a3cc/rich-14.3.1-py3-none-any.whl", hash = "sha256:da750b1aebbff0b372557426fb3f35ba56de8ef954b3190315eb64076d6fb54e", size = 309952, upload-time = "2026-01-24T21:40:42.969Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a new API and CLI system for querying UFC fight data:

- FastAPI server with read-only endpoints:
  - /fighter - search fighters by name/division
  - /fighter/{uid} - get fighter details and fight history
  - /upcoming - list upcoming events and matchups
  - /rankings - fighter rankings by win rate per division
  - /roster - search roster with filters (stance, stats, etc.)
  - /events - list UFC events
  - /fight/{uid} - detailed fight statistics

- Typer CLI that queries the API:
  - panoctagon data fighter/upcoming/rankings/roster/events/fight
  - Supports --format json|table for output
  - Markdown table formatting for terminal display

- New serve command to start the API server:
  - panoctagon serve [--host] [--port] [--reload]

https://claude.ai/code/session_01SoB6iDJ6EP35eJZBYqvQoS